### PR TITLE
:bug: testcase crash for gcc skip catch on destructor

### DIFF
--- a/tests/ut/TestMockObject2.h
+++ b/tests/ut/TestMockObject2.h
@@ -32,7 +32,7 @@ class TestMockObject2 : public TESTCPP_NS::TestFixture
    {
       virtual int  base00() = 0;
       virtual bool base01(long) const = 0;
-      virtual ~Base0() {}
+      virtual ~Base0() noexcept(false) {}
    };
 
    struct Base1
@@ -41,7 +41,7 @@ class TestMockObject2 : public TESTCPP_NS::TestFixture
       virtual long base11(const std::string&) const = 0;
       virtual int  base12() const = 0;
 
-      virtual ~Base1() {}
+      virtual ~Base1() noexcept(false) {}
    };
 
    struct Interface: public Base0, public Base1

--- a/tests/ut/TestVirtualTable.h
+++ b/tests/ut/TestVirtualTable.h
@@ -52,7 +52,7 @@ class TestVirtualTable: public TESTCPP_NS::TestFixture
    {
       virtual int  base00() = 0;
       virtual bool base01(int) const = 0;
-      virtual ~Base0() {}
+      virtual ~Base0() noexcept(false) {}
    };
 
    struct Base1
@@ -60,7 +60,7 @@ class TestVirtualTable: public TESTCPP_NS::TestFixture
       virtual void base10() = 0;
       virtual long base11(bool) const = 0;
 
-      virtual ~Base1() {}
+      virtual ~Base1() noexcept(false) {}
    };
 
    struct Interface: public Base0, public Base1


### PR DESCRIPTION
for c++11, destrcutor taken defaultly as noexcept(true), so gcc may skip catch block over destractor.

From https://en.cppreference.com/w/cpp/language/destructor#Exceptions

> As any other function, a destructor may terminate by throwing an exception (this usually requires it to be explicitly declared noexcept(false)) (since C++11)

This fix will close #16 