### PR TITLE
add support for immutable lambda checker

### DIFF
--- a/include/mockcpp/ChainingMockHelper.h
+++ b/include/mockcpp/ChainingMockHelper.h
@@ -103,6 +103,12 @@ struct PredictTypeTraits<bool (Predict::*)(T)>
     typedef T ParaType;
 };
 
+template <typename Predict, typename T>
+struct PredictTypeTraits<bool (Predict::*)(T) const>
+{
+    typedef T ParaType;
+};
+
 template <typename Predict>
 Constraint* checkWith(Predict pred)
 {

--- a/tests/ut/TestCheck.h
+++ b/tests/ut/TestCheck.h
@@ -139,5 +139,31 @@ FIXTURE(Check)
 
 		ASSERT_EQ(10, input.a);
 	}
+
+	TEST(Can check with mutable lambda)
+	{
+		MOCK_METHOD(mocker, method)
+			.expects(once())
+			.with(checkWith([](STRUCT_T *p) mutable {
+				return p->b == 2;
+			}));
+
+		client(mocker, &input);
+
+		ASSERT_EQ(10, input.a);
+	}
+
+	TEST(Can check with immutable lambda)
+	{
+		MOCK_METHOD(mocker, method)
+			.expects(once())
+			.with(checkWith([](STRUCT_T *p) {
+				return p->b == 2;
+			}));
+
+		client(mocker, &input);
+
+		ASSERT_EQ(10, input.a);
+	}
 };
 


### PR DESCRIPTION
When testcase use lambda expression with `checkWith`, will compile failed with gcc8.3, debian OS.
```c++
	TEST(Can check with immutable lambda)
	{
		MOCK_METHOD(mocker, method)
			.expects(once())
			.with(checkWith([](STRUCT_T *p) {
				return p->b == 2;
			}));

		client(mocker, &input);

		ASSERT_EQ(10, input.a);
	}
```

[ 85%] Building CXX object ut/CMakeFiles/mockcpp-ut-TestCheck.dir/TestCheck.cpp.o
In file included from /mnt/d/Works/OpenSource/mockcpp/tests/../include/mockcpp/mockcpp.hpp:23,
                 from /mnt/d/Works/OpenSource/mockcpp/tests/ut/TestCheck.h:21,
                 from /mnt/d/Works/OpenSource/mockcpp/tests/ut/TestCheck.cpp:5:
/mnt/d/Works/OpenSource/mockcpp/tests/../include/mockcpp/ChainingMockHelper.h: In instantiation of ‘mockcpp::Constraint* mockcpp::checkWith(Predict) [with Predict = TestCheck::test_143()::<lambda(STRUCT_T*)>]’:
/mnt/d/Works/OpenSource/mockcpp/tests/ut/TestCheck.h:149:5:   required from here
/mnt/d/Works/OpenSource/mockcpp/tests/../include/mockcpp/ChainingMockHelper.h:109:91: error: no type named ‘ParaType’ in ‘struct mockcpp::PredictTypeTraits<bool (TestCheck::test_143()::<lambda(STRUCT_T*)>::*)(STRUCT_T*) const>’
     typedef typename PredictTypeTraits<FAKE_BOOST_TYPEOF(&Predict::operator())>::ParaType T;
                                                                                           ^
/mnt/d/Works/OpenSource/mockcpp/tests/../include/mockcpp/ChainingMockHelper.h:110:12: error: no type named ‘ParaType’ in ‘struct mockcpp::PredictTypeTraits<bool (TestCheck::test_143()::<lambda(STRUCT_T*)>::*)(STRUCT_T*) const>’
     return new CheckWith<T, Predict>(pred);
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [ut/CMakeFiles/mockcpp-ut-TestCheck.dir/build.make:67: ut/CMakeFiles/mockcpp-ut-TestCheck.dir/TestCheck.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1979: ut/CMakeFiles/mockcpp-ut-TestCheck.dir/all] Error 2
make: *** [Makefile:84: all] Error 2