### PR TITLE
Remove compile warning for format.h

### DIFF
--- a/tests/3rdparty/testngpp/include/mem_checker/format.h
+++ b/tests/3rdparty/testngpp/include/mem_checker/format.h
@@ -76,7 +76,7 @@ struct SrcAddr
 	        file = last_info;
 	        if (!print_position_from_addr(_instruction, line, last_info, sizeof(last_info))) // fail to get source location
 	        {
-	        	sprintf(last_info, "instruction 0x%016lX", (unsigned long long)_instruction);
+	        	sprintf(last_info, "instruction 0x%016llX", (unsigned long long)_instruction);
 	        }
 	    }
 	}

--- a/tests/ut/TestCheck.h
+++ b/tests/ut/TestCheck.h
@@ -159,8 +159,8 @@ FIXTURE(Check)
 		MOCK_METHOD(mocker, method)
 			.expects(once())
 			.with(checkWith([](STRUCT_T *p) {
-			    p->a = 10;
-				return p->b == 2;
+                p->a = 10;
+                return p->b == 2;
 			}));
 
 		client(mocker, &input);

--- a/tests/ut/TestCheck.h
+++ b/tests/ut/TestCheck.h
@@ -145,6 +145,7 @@ FIXTURE(Check)
 		MOCK_METHOD(mocker, method)
 			.expects(once())
 			.with(checkWith([](STRUCT_T *p) mutable {
+                p->a = 10;
 				return p->b == 2;
 			}));
 
@@ -158,6 +159,7 @@ FIXTURE(Check)
 		MOCK_METHOD(mocker, method)
 			.expects(once())
 			.with(checkWith([](STRUCT_T *p) {
+			    p->a = 10;
 				return p->b == 2;
 			}));
 


### PR DESCRIPTION
OS: MAC OS
IDE: CLION
Compile Warning: 

/Users/zyg/Documents/workspace/mockcpp/tests/3rdparty/testngpp/include/mem_checker/format.h:79:54: warning: format specifies type 'unsigned long' but the argument has type 'unsigned long long'
      [-Wformat]
                        sprintf(last_info, "instruction 0x%016lX", (unsigned long long)_instruction);
                                                          ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                          %016llX
1 warning generated.
