### PR TITLE
fix compile warning : Reorder in OutBound ctor

### DIFF
--- a/include/mockcpp/OutBound.h
+++ b/include/mockcpp/OutBound.h
@@ -30,7 +30,7 @@ template <typename T>
 struct OutBound : public DecoratedConstraint
 {
     OutBound(const T& val, Constraint* constraint = 0)
-      : ref(val), DecoratedConstraint(constraint)
+      : DecoratedConstraint(constraint), ref(val)
     {}
 
     bool evalSelf(const RefAny& val) const


### PR DESCRIPTION
Fix #43

自验证代码
```
#include <mockcpp/OutBound.h>
int var;
mockcpp::OutBound<int> p(var, nullptr);
```


