### PR TITLE
improve portability of Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,19 +27,23 @@ cmake_force:
 # Set environment variables for the build.
 
 # The shell in which to execute make rules.
-SHELL = /bin/sh
+SHELL := /bin/sh
 
 # The CMake executable.
-CMAKE_COMMAND = /usr/local/bin/cmake
+CMAKE_COMMAND := $(shell which cmake)
 
 # The command to remove a file.
-RM = /usr/local/bin/cmake -E remove -f
+RM := $(CMAKE_COMMAND) -E remove -f
+
+# The top-level source directory.
+SRC_ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
 # The top-level source directory on which CMake was run.
-CMAKE_SOURCE_DIR = /home/topcoder/mockcpp/mockcpp
+CMAKE_SOURCE_DIR := $(SRC_ROOT_DIR)
+
 
 # The top-level build directory on which CMake was run.
-CMAKE_BINARY_DIR = /home/topcoder/mockcpp/mockcpp
+CMAKE_BINARY_DIR := $(SRC_ROOT_DIR)
 
 #=============================================================================
 # Targets provided globally by CMake.
@@ -47,7 +51,7 @@ CMAKE_BINARY_DIR = /home/topcoder/mockcpp/mockcpp
 # Special rule for the target edit_cache
 edit_cache:
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running interactive CMake command-line interface..."
-	/usr/local/bin/cmake -i .
+	$(CMAKE_COMMAND) -i .
 .PHONY : edit_cache
 
 # Special rule for the target edit_cache
@@ -57,19 +61,19 @@ edit_cache/fast: edit_cache
 # Special rule for the target install
 install: preinstall
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Install the project..."
-	/usr/local/bin/cmake -P cmake_install.cmake
+	$(CMAKE_COMMAND) -P cmake_install.cmake
 .PHONY : install
 
 # Special rule for the target install
 install/fast: preinstall/fast
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Install the project..."
-	/usr/local/bin/cmake -P cmake_install.cmake
+	$(CMAKE_COMMAND) -P cmake_install.cmake
 .PHONY : install/fast
 
 # Special rule for the target install/local
 install/local: preinstall
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Installing only the local directory..."
-	/usr/local/bin/cmake -DCMAKE_INSTALL_LOCAL_ONLY=1 -P cmake_install.cmake
+	$(CMAKE_COMMAND) -DCMAKE_INSTALL_LOCAL_ONLY=1 -P cmake_install.cmake
 .PHONY : install/local
 
 # Special rule for the target install/local
@@ -79,7 +83,7 @@ install/local/fast: install/local
 # Special rule for the target install/strip
 install/strip: preinstall
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Installing the project stripped..."
-	/usr/local/bin/cmake -DCMAKE_INSTALL_DO_STRIP=1 -P cmake_install.cmake
+	$(CMAKE_COMMAND) -DCMAKE_INSTALL_DO_STRIP=1 -P cmake_install.cmake
 .PHONY : install/strip
 
 # Special rule for the target install/strip
@@ -98,7 +102,7 @@ list_install_components/fast: list_install_components
 # Special rule for the target rebuild_cache
 rebuild_cache:
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running CMake to regenerate build system..."
-	/usr/local/bin/cmake -H$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR)
+	$(CMAKE_COMMAND) -H$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR)
 .PHONY : rebuild_cache
 
 # Special rule for the target rebuild_cache
@@ -203,4 +207,3 @@ help:
 cmake_check_build_system:
 	$(CMAKE_COMMAND) -H$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 0
 .PHONY : cmake_check_build_system
-

--- a/tests/3rdparty/testngpp/Makefile
+++ b/tests/3rdparty/testngpp/Makefile
@@ -27,19 +27,26 @@ cmake_force:
 # Set environment variables for the build.
 
 # The shell in which to execute make rules.
-SHELL = /bin/sh
+SHELL := /bin/sh
 
 # The CMake executable.
-CMAKE_COMMAND = /usr/local/bin/cmake
+CMAKE_COMMAND := $(shell which cmake)
 
 # The command to remove a file.
-RM = /usr/local/bin/cmake -E remove -f
+RM := $(CMAKE_COMMAND) -E remove -f
+
+# The top-level source directory.
+SRC_ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
+TEST_NG_PP_SRC_ROOT_DIR := $(realpath "$(SRC_ROOT_DIR)/../../../../test-ng-pp")
 
 # The top-level source directory on which CMake was run.
-CMAKE_SOURCE_DIR = /home/topcoder/test-ng-pp
+# CMAKE_SOURCE_DIR = /home/topcoder/test-ng-pp
+CMAKE_SOURCE_DIR := $(TEST_NG_PP_SRC_ROOT_DIR)
 
 # The top-level build directory on which CMake was run.
-CMAKE_BINARY_DIR = /home/topcoder/test-ng-pp
+# CMAKE_BINARY_DIR = /home/topcoder/test-ng-pp
+CMAKE_BINARY_DIR := $(TEST_NG_PP_SRC_ROOT_DIR)
 
 #=============================================================================
 # Targets provided globally by CMake.
@@ -343,4 +350,3 @@ help:
 cmake_check_build_system:
 	$(CMAKE_COMMAND) -H$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 0
 .PHONY : cmake_check_build_system
-


### PR DESCRIPTION
Improve portability of Makefiles by finding the `cmake` tool in the user's path, rather than hardcoding it.
On MSYS2 environment, `cmake` is located at:
- `/ucrt64/bin/cmake` (for UCRT64 environment)
- `/usr/bin/cmake` (for MSYS2 environment)

Improve portability by not hard coding top-level directory path.  Instead determine top-level path from the current Makefile.

For `test-ng-pp` I took the liberty of assuming `test-ng` was installed alongside `mockcpp`, made the directory relative to it.