### PR TITLE
Fix compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,19 +27,23 @@ cmake_force:
 # Set environment variables for the build.
 
 # The shell in which to execute make rules.
-SHELL = /bin/sh
+SHELL := /bin/sh
 
 # The CMake executable.
-CMAKE_COMMAND = /usr/local/bin/cmake
+CMAKE_COMMAND := $(shell which cmake)
 
 # The command to remove a file.
-RM = /usr/local/bin/cmake -E remove -f
+RM := $(CMAKE_COMMAND) -E remove -f
+
+# The top-level source directory.
+SRC_ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
 # The top-level source directory on which CMake was run.
-CMAKE_SOURCE_DIR = /home/topcoder/mockcpp/mockcpp
+CMAKE_SOURCE_DIR := $(SRC_ROOT_DIR)
+
 
 # The top-level build directory on which CMake was run.
-CMAKE_BINARY_DIR = /home/topcoder/mockcpp/mockcpp
+CMAKE_BINARY_DIR := $(SRC_ROOT_DIR)
 
 #=============================================================================
 # Targets provided globally by CMake.
@@ -47,7 +51,7 @@ CMAKE_BINARY_DIR = /home/topcoder/mockcpp/mockcpp
 # Special rule for the target edit_cache
 edit_cache:
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running interactive CMake command-line interface..."
-	/usr/local/bin/cmake -i .
+	$(CMAKE_COMMAND) -i .
 .PHONY : edit_cache
 
 # Special rule for the target edit_cache
@@ -57,19 +61,19 @@ edit_cache/fast: edit_cache
 # Special rule for the target install
 install: preinstall
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Install the project..."
-	/usr/local/bin/cmake -P cmake_install.cmake
+	$(CMAKE_COMMAND) -P cmake_install.cmake
 .PHONY : install
 
 # Special rule for the target install
 install/fast: preinstall/fast
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Install the project..."
-	/usr/local/bin/cmake -P cmake_install.cmake
+	$(CMAKE_COMMAND) -P cmake_install.cmake
 .PHONY : install/fast
 
 # Special rule for the target install/local
 install/local: preinstall
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Installing only the local directory..."
-	/usr/local/bin/cmake -DCMAKE_INSTALL_LOCAL_ONLY=1 -P cmake_install.cmake
+	$(CMAKE_COMMAND) -DCMAKE_INSTALL_LOCAL_ONLY=1 -P cmake_install.cmake
 .PHONY : install/local
 
 # Special rule for the target install/local
@@ -79,7 +83,7 @@ install/local/fast: install/local
 # Special rule for the target install/strip
 install/strip: preinstall
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Installing the project stripped..."
-	/usr/local/bin/cmake -DCMAKE_INSTALL_DO_STRIP=1 -P cmake_install.cmake
+	$(CMAKE_COMMAND) -DCMAKE_INSTALL_DO_STRIP=1 -P cmake_install.cmake
 .PHONY : install/strip
 
 # Special rule for the target install/strip
@@ -98,7 +102,7 @@ list_install_components/fast: list_install_components
 # Special rule for the target rebuild_cache
 rebuild_cache:
 	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --cyan "Running CMake to regenerate build system..."
-	/usr/local/bin/cmake -H$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR)
+	$(CMAKE_COMMAND) -H$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR)
 .PHONY : rebuild_cache
 
 # Special rule for the target rebuild_cache
@@ -203,4 +207,3 @@ help:
 cmake_check_build_system:
 	$(CMAKE_COMMAND) -H$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 0
 .PHONY : cmake_check_build_system
-

--- a/include/mockcpp/ApiHook.h
+++ b/include/mockcpp/ApiHook.h
@@ -32,7 +32,7 @@ struct ApiHook
     ~ApiHook();
 
 private:
-    ApiHookImpl* This;;
+    ApiHookImpl* This;
 };
 
 MOCKCPP_NS_END

--- a/include/mockcpp/ApiHookGenerator.h
+++ b/include/mockcpp/ApiHookGenerator.h
@@ -48,7 +48,7 @@ struct ApiHookGenerator
 
     static bool freeApiHook(void* hook)
     {
-        return 
+        return
         (ApiHookFunctor<F, Seq>::freeApiHook(hook)) ||
         (ApiHookGenerator<F, Seq-1>::freeApiHook(hook));
     }
@@ -62,12 +62,17 @@ template <typename F>
 struct ApiHookGenerator<F, 0>
 {
     static void* findApiHook(F* api)
-    { return 0; }
+    {
+        (void)api;
+        return 0;
+    }
 
     static void* appyApiHook(F* api)
-    { 
+    {
+        (void)api;
+
         oss_t oss;
-        
+
         oss << "Did you define too many mockers in a testcase? "
             << "Probably you should refine your design, "
             << "or you can reconfig ParameterizedApiHookHolder::maxSeq bigger, "
@@ -75,12 +80,15 @@ struct ApiHookGenerator<F, 0>
             << "the bigger it is, the slower compiling is.";
 
         MOCKCPP_REPORT_FAILURE(oss.str());
-   
-        return 0; 
+
+        return 0;
     }
 
     static bool freeApiHook(void* hook)
-    { return true; }
+    {
+        (void)hook;
+        return true;
+    }
 };
 
 /////////////////////////////////////////////////////////////////
@@ -88,4 +96,3 @@ struct ApiHookGenerator<F, 0>
 MOCKCPP_NS_END
 
 #endif
-

--- a/include/mockcpp/ChainableMockMethod.h
+++ b/include/mockcpp/ChainableMockMethod.h
@@ -90,7 +90,7 @@ struct ChainableMockMethod : public ChainableMockMethodBase<RT>
     RT getResult(const Any& anyResult, SelfDescribe* resultProvider)
     {
       const Any& result = \
-              Result( any_castable<RT>(anyResult) 
+              Result( any_castable<RT>(anyResult)
                     , typeid(RT)
                     , TypeString<RT>::value()
                     , resultProvider).getResult(anyResult);
@@ -115,6 +115,7 @@ struct ChainableMockMethod<void> : public ChainableMockMethodBase<void>
 {
     void getResult(const Any& result, SelfDescribe*)
     {
+      (void)result;
     }
 
 public:
@@ -129,4 +130,3 @@ public:
 MOCKCPP_NS_END
 
 #endif
-

--- a/include/mockcpp/Ignore.h
+++ b/include/mockcpp/Ignore.h
@@ -26,6 +26,7 @@ struct Ignore
 {
    bool operator==(const Ignore& rhs) const
    {
+      (void)rhs;
       return true;
    }
 };
@@ -37,4 +38,3 @@ Any& getIgnore();
 MOCKCPP_NS_END
 
 #endif
-

--- a/include/mockcpp/InvocationMocker.h
+++ b/include/mockcpp/InvocationMocker.h
@@ -43,7 +43,7 @@ struct InvocationMocker : public SelfDescribe
     bool hasBeenInvoked(void) const ;
 
     void setId(InvocationId* id);
-    const InvocationId* const getId(void) const;
+    const InvocationId* getId(void) const;
 
     bool matches(const Invocation& inv) const;
     Any& invoke(const Invocation& inv);
@@ -59,4 +59,3 @@ private:
 MOCKCPP_NS_END
 
 #endif
-

--- a/include/mockcpp/ProcStub.h
+++ b/include/mockcpp/ProcStub.h
@@ -42,7 +42,7 @@ struct ProcStubBase : public Stub
     bool isCompleted() const;
 
     std::string toString() const;
-    
+
 private:
 
     ProcStubBaseImpl* This;
@@ -59,11 +59,11 @@ std::string getParameterMismatchString(int n
                     getParameterMismatchString(N, TypeString<MOCKP##N>::value(), inv) \
                         , any_castable<MOCKP##N>(inv.getParameter(N))); \
         MOCKP##N p##N = any_cast<MOCKP##N>(inv.getParameter(N));
-    
+
 #define PROC_STUB_CONS()  \
     ProcStub(Func f, std::string name) \
         : ProcStubBase(name, (void*)f), func(f) \
-    {} 
+    {}
 
 
 ///////////////////////////////////////////////////////////
@@ -101,6 +101,7 @@ struct ProcStub<void(DECL_ARGS(n))> : public ProcStubBase \
  \
     Any& invoke(const Invocation& inv) \
     { \
+        (void)inv; \
         SIMPLE_REPEAT(n, MOCKCPP_CHECK_AND_ASSIGN_PARAMETER); \
  \
         func(DECL_PARAMS(n)); \
@@ -161,6 +162,7 @@ struct ProcStub<void(DECL_VARDIC_ARGS(n) ...)> : public ProcStubBase \
  \
     Any& invoke(const Invocation& inv) \
     { \
+        (void)inv; \
         SIMPLE_REPEAT(n, MOCKCPP_CHECK_AND_ASSIGN_PARAMETER); \
  \
         func(DECL_PARAMS(n)); \
@@ -190,4 +192,3 @@ VARDIC_PROC_STUB_DEF(8);
 MOCKCPP_NS_END
 
 #endif
-

--- a/include/mockcpp/StatelessMatcher.h
+++ b/include/mockcpp/StatelessMatcher.h
@@ -29,10 +29,9 @@ struct StatelessMatcher : public Matcher
 {
     virtual ~StatelessMatcher() {}
     virtual bool matches(const Invocation& inv) const = 0;
-    virtual void increaseInvoked(const Invocation& inv) {}
+    virtual void increaseInvoked(const Invocation& inv) { (void)inv; }
 };
 
 MOCKCPP_NS_END
 
 #endif
-

--- a/include/mockcpp/mockcpp.h
+++ b/include/mockcpp/mockcpp.h
@@ -26,16 +26,16 @@
 # define MOCKCPP_NS_END }
 # define USING_MOCKCPP_NS using namespace MOCKCPP_NS;
 #else
-# define MOCKCPP_NS 
-# define MOCKCPP_NS_START 
-# define MOCKCPP_NS_END 
-# define USING_MOCKCPP_NS 
+# define MOCKCPP_NS
+# define MOCKCPP_NS_START
+# define MOCKCPP_NS_END
+# define USING_MOCKCPP_NS
 #endif
 
 #ifdef _MSC_VER
 # define MOCKCPP_EXPORT __declspec(dllexport)
 #else
-# define MOCKCPP_EXPORT 
+# define MOCKCPP_EXPORT
 #endif
 
 
@@ -48,7 +48,7 @@
 #define BUILD_FOR_X64 1
 #define BUILD_FOR_X86 0
 
-#else	
+#else
 
 #define BUILD_FOR_X64 0
 #define BUILD_FOR_X86 1
@@ -57,4 +57,3 @@
 
 
 #endif // __MOCKCPP_H
-

--- a/include/mockcpp/types/ValueHolder.h
+++ b/include/mockcpp/types/ValueHolder.h
@@ -60,6 +60,7 @@ Constraint* constraint(const Constraint* c)
 
 Constraint* constraint(const Void& v)
 {
+    (void)v;
     return any();
 }
 
@@ -122,7 +123,7 @@ public:
 
 ///////////////////////////////////////////////
 template <>
-struct ValueHolder<unsigned long> 
+struct ValueHolder<unsigned long>
    : public UnsignedLongHolder<unsigned long>
 {
     ValueHolder(unsigned long value)
@@ -141,7 +142,7 @@ struct ValueHolder<unsigned long>
 
 ///////////////////////////////////////////////
 template <>
-struct ValueHolder<unsigned int> 
+struct ValueHolder<unsigned int>
    : public UnsignedLongHolder<unsigned int>
 {
     ValueHolder(unsigned int value)
@@ -160,7 +161,7 @@ struct ValueHolder<unsigned int>
 
 ///////////////////////////////////////////////
 template <>
-struct ValueHolder<unsigned short> 
+struct ValueHolder<unsigned short>
    : public UnsignedLongHolder<unsigned short>
 {
     ValueHolder(unsigned short value)
@@ -179,7 +180,7 @@ struct ValueHolder<unsigned short>
 
 ///////////////////////////////////////////////
 template <>
-struct ValueHolder<unsigned char> 
+struct ValueHolder<unsigned char>
    : public UnsignedLongHolder<unsigned char>
 {
     ValueHolder(unsigned char value)
@@ -221,7 +222,7 @@ public:
 
 ///////////////////////////////////////////////
 template <>
-struct ValueHolder<long> 
+struct ValueHolder<long>
    : public SignedLongHolder<long>
 {
     ValueHolder(const long& value)
@@ -240,7 +241,7 @@ struct ValueHolder<long>
 
 ///////////////////////////////////////////////
 template <>
-struct ValueHolder<int> 
+struct ValueHolder<int>
    : public SignedLongHolder<int>
 {
     ValueHolder(const int& value)
@@ -259,7 +260,7 @@ struct ValueHolder<int>
 
 ///////////////////////////////////////////////
 template <>
-struct ValueHolder<short> 
+struct ValueHolder<short>
    : public SignedLongHolder<short>
 {
     ValueHolder(const short& value)
@@ -278,7 +279,7 @@ struct ValueHolder<short>
 
 ///////////////////////////////////////////////
 template <>
-struct ValueHolder<char> 
+struct ValueHolder<char>
    : public SignedLongHolder<char>
 {
     ValueHolder(const char& value)
@@ -301,5 +302,3 @@ MOCKCPP_NS_END
 
 
 #endif // __MOCKPP_VALUEHOLDER_H
-
-

--- a/src/AfterMatcher.cpp
+++ b/src/AfterMatcher.cpp
@@ -31,12 +31,15 @@ AfterMatcher::AfterMatcher()
 //////////////////////////////////////////////////////
 bool AfterMatcher::matches(const Invocation& inv) const
 {
+    (void)inv;
     return true;
 }
 
 //////////////////////////////////////////////////////
 void AfterMatcher::increaseInvoked(const Invocation& inv)
 {
+    (void)inv;  
+
     oss_t oss;
 
     oss << "Expected invoked after the invocation with id \""
@@ -44,7 +47,7 @@ void AfterMatcher::increaseInvoked(const Invocation& inv)
         << "\", but that invocation has NOT been invoked yet.";
 
     MOCKCPP_ASSERT_TRUE_MESSAGE(
-         oss.str(), 
+         oss.str(),
          previousCall->hasBeenInvoked());
 }
 
@@ -55,7 +58,7 @@ std::string AfterMatcher::toString() const
 }
 
 //////////////////////////////////////////////////////
-void AfterMatcher::verify() 
+void AfterMatcher::verify()
 {
 }
 
@@ -72,4 +75,3 @@ void AfterMatcher::setOrderingInvocationMocker(InvocationMocker* mocker)
 }
 
 MOCKCPP_NS_END
-

--- a/src/AfterMatcher.cpp
+++ b/src/AfterMatcher.cpp
@@ -38,7 +38,7 @@ bool AfterMatcher::matches(const Invocation& inv) const
 //////////////////////////////////////////////////////
 void AfterMatcher::increaseInvoked(const Invocation& inv)
 {
-    (void)inv;  
+    (void)inv;
 
     oss_t oss;
 

--- a/src/AnyCast.cpp
+++ b/src/AnyCast.cpp
@@ -24,6 +24,7 @@ MOCKCPP_NS_START
 template <typename ValueType>
 ValueType* type_any_cast(AnyBase* op)
 {
+   (void)op;
    return 0;
 }
 
@@ -133,7 +134,7 @@ ValueType* scope_check_any_cast(AnyBase* op)
    }
 
    long* l = type_any_cast<long>(op);
-   if(l  && (((*l) <= (long)std::numeric_limits<ValueType>::max()) && 
+   if(l  && (((*l) <= (long)std::numeric_limits<ValueType>::max()) &&
               (*l) >= (long)std::numeric_limits<ValueType>::min()))
    {
       return (ValueType*)l;
@@ -199,4 +200,3 @@ unsigned long* any_cast<unsigned long>(AnyBase* op)
 }
 
 MOCKCPP_NS_END
-

--- a/src/ApiHookKey.cpp
+++ b/src/ApiHookKey.cpp
@@ -23,15 +23,14 @@ MOCKCPP_NS_START
 
 ///////////////////////////////////////////////////////////
 ApiHookKey::ApiHookKey(const void* api, ApiHookHolder* holder)
-   : apiAddress(api)
-   , hookHolder(holder)
+   : hookHolder(holder), apiAddress(api)
 {
    hook = new ApiHook(api, holder->getApiHook());
 }
 
 ///////////////////////////////////////////////////////////
 ApiHookKey::ApiHookKey(const void* api)
-   : apiAddress(api), hook(0), hookHolder(0)
+   : hook(0), hookHolder(0), apiAddress(api)
 {
 }
 
@@ -40,7 +39,7 @@ ApiHookKey::~ApiHookKey()
 {
    delete hook;
    delete hookHolder;
-}   
+}
 
 ////////////////////////////////////////////////////////////
 bool ApiHookKey::equals(
@@ -63,7 +62,7 @@ bool ApiHookKey::equals(
     {
        return false;
     }
-     
+
     return key->apiAddress == this->apiAddress;
 }
 

--- a/src/BeforeMatcher.cpp
+++ b/src/BeforeMatcher.cpp
@@ -32,15 +32,18 @@ BeforeMatcher::BeforeMatcher()
 //////////////////////////////////////////////////////
 bool BeforeMatcher::matches(const Invocation& inv) const
 {
+    (void)inv;
     return true;
 }
 
 //////////////////////////////////////////////////////
 void BeforeMatcher::increaseInvoked(const Invocation& inv)
 {
+    (void)inv;
+
     oss_t oss;
 
-    oss << "Expected invoked before the invocation with id \"" 
+    oss << "Expected invoked before the invocation with id \""
         << previousCall->getId()->getId()
         << "\", but that invocation has been invoked.";
 
@@ -56,7 +59,7 @@ std::string BeforeMatcher::toString() const
 }
 
 //////////////////////////////////////////////////////
-void BeforeMatcher::verify() 
+void BeforeMatcher::verify()
 {
 }
 
@@ -73,4 +76,3 @@ void BeforeMatcher::setOrderingInvocationMocker(InvocationMocker* mocker)
 }
 
 MOCKCPP_NS_END
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ IF(NOT DEFINED MOCKCPP_XUNIT)
 ENDIF()
 
 
-   
+
 # Set MOCKCPP_MAX_INHERITANCE
 #
 IF(MOCKCPP_ALLOW_MI)
@@ -64,12 +64,12 @@ ADD_DEFINITIONS(
 )
 
 FIND_FILE(BOOST_HEADER
-            typeof.hpp 
-            PATHS ${MOCKCPP_SRC_ROOT}/3rdparty/boost/typeof 
-            NO_DEFAULT_PATH 
-            NO_CMAKE_ENVIRONMENT_PATH 
-            NO_CMAKE_PATH 
-            NO_SYSTEM_ENVIRONMENT_PATH 
+            typeof.hpp
+            PATHS ${MOCKCPP_SRC_ROOT}/3rdparty/boost/typeof
+            NO_DEFAULT_PATH
+            NO_CMAKE_ENVIRONMENT_PATH
+            NO_CMAKE_PATH
+            NO_SYSTEM_ENVIRONMENT_PATH
             NO_CMAKE_SYSTEM_PATH)
 IF(NOT EXISTS ${BOOST_HEADER})
 ADD_DEFINITIONS(-DNO_BOOST=1)
@@ -80,7 +80,8 @@ IF(MSVC)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /vmg")
 	INCLUDE_DIRECTORIES(BEFORE ${MOCKCPP_SRC_ROOT}/3rdparty/msinttypes)
 ELSE(MSVC)
-    ADD_DEFINITIONS(-std=c++11)
+    # ADD_DEFINITIONS(-std=c++11)
+    ADD_DEFINITIONS(-std=c++11 -Werror -Wall -Wextra -Wpedantic)
 ENDIF(MSVC)
 
 #IF(UNIX)
@@ -100,7 +101,7 @@ IF(CMAKE_CL_64)
     ADD_DEFINITIONS(-DWIN64)
 ENDIF(CMAKE_CL_64)
 
-SET(MOCKCPP_SRCS 
+SET(MOCKCPP_SRCS
     AfterMatcher.cpp
     AnyBase.cpp
     AnyCast.cpp
@@ -189,12 +190,12 @@ IF(${MOCKCPP_XUNIT} STREQUAL "GTEST" OR ${MOCKCPP_XUNIT} STREQUAL "gtest")
       MESSAGE(FATAL_ERROR "Please specify MOCKCPP_XUNIT_HOME as the home path of googletest")
    ENDIF()
    FIND_FILE(GTEST_HEADER
-             gtest.h 
-             PATHS ${MOCKCPP_XUNIT_HOME}/include/gtest 
-             NO_DEFAULT_PATH 
-             NO_CMAKE_ENVIRONMENT_PATH 
-             NO_CMAKE_PATH 
-             NO_SYSTEM_ENVIRONMENT_PATH 
+             gtest.h
+             PATHS ${MOCKCPP_XUNIT_HOME}/include/gtest
+             NO_DEFAULT_PATH
+             NO_CMAKE_ENVIRONMENT_PATH
+             NO_CMAKE_PATH
+             NO_SYSTEM_ENVIRONMENT_PATH
              NO_CMAKE_SYSTEM_PATH)
    IF(NOT EXISTS ${GTEST_HEADER})
       MESSAGE(FATAL_ERROR "gtest.h not found in ${MOCKCPP_XUNIT_HOME}/include/gtest, please specify MOCKCPP_XUNIT_HOME as the home path of googletest correctly.")
@@ -208,29 +209,29 @@ ELSEIF(${MOCKCPP_XUNIT} STREQUAL "CppUTest" OR ${MOCKCPP_XUNIT} STREQUAL "cppute
       MESSAGE(FATAL_ERROR "Please specify MOCKCPP_XUNIT_HOME as the home path of googletest")
    ENDIF()
    FIND_FILE(CPPUTEST_HEADER
-             TestHarness.h 
+             TestHarness.h
              PATHS ${MOCKCPP_XUNIT_HOME}/include/CppUTest
-             NO_DEFAULT_PATH 
-             NO_CMAKE_ENVIRONMENT_PATH 
-             NO_CMAKE_PATH 
-             NO_SYSTEM_ENVIRONMENT_PATH 
+             NO_DEFAULT_PATH
+             NO_CMAKE_ENVIRONMENT_PATH
+             NO_CMAKE_PATH
+             NO_SYSTEM_ENVIRONMENT_PATH
              NO_CMAKE_SYSTEM_PATH)
    IF(NOT EXISTS ${CPPUTEST_HEADER})
       MESSAGE(FATAL_ERROR "TestHarness.h not found in ${MOCKCPP_XUNIT_HOME}/include/CppUTest, please specify MOCKCPP_XUNIT_HOME as the home path of CppUTest correctly.")
    ENDIF()
    INCLUDE_DIRECTORIES(BEFORE ${MOCKCPP_XUNIT_HOME}/include ${MOCKCPP_XUNIT_HOME}/include/Platforms/VisualCpp)
-   SET(MOCKCPP_SRCS ${MOCKCPP_SRCS} ports/failure/cpputest_report_failure.cpp)   
-   
+   SET(MOCKCPP_SRCS ${MOCKCPP_SRCS} ports/failure/cpputest_report_failure.cpp)
+
 ELSEIF(${MOCKCPP_XUNIT} STREQUAL "CPPUNIT" OR ${MOCKCPP_XUNIT} STREQUAL "cppunit")
    IF(NOT DEFINED MOCKCPP_XUNIT_HOME)
       MESSAGE(FATAL_ERROR "Please specify MOCKCPP_XUNIT_HOME as the home path of cppunit")
    ENDIF()
-   FIND_FILE(CPPUNIT_HEADER Exception.h 
+   FIND_FILE(CPPUNIT_HEADER Exception.h
              PATHS ${MOCKCPP_XUNIT_HOME}/include/cppunit
-             NO_DEFAULT_PATH 
-             NO_CMAKE_ENVIRONMENT_PATH 
-             NO_CMAKE_PATH 
-             NO_SYSTEM_ENVIRONMENT_PATH 
+             NO_DEFAULT_PATH
+             NO_CMAKE_ENVIRONMENT_PATH
+             NO_CMAKE_PATH
+             NO_SYSTEM_ENVIRONMENT_PATH
              NO_CMAKE_SYSTEM_PATH)
    IF(NOT EXISTS ${CPPUNIT_HEADER})
       MESSAGE(FATAL_ERROR "Can't find file Exception.h, please specify MOCKCPP_XUNIT_HOME as the home path of cppunit correctly.")
@@ -242,12 +243,12 @@ ELSEIF(${MOCKCPP_XUNIT} STREQUAL "Catch2" OR ${MOCKCPP_XUNIT} STREQUAL "catch2")
       MESSAGE(FATAL_ERROR "Please specify MOCKCPP_XUNIT_HOME as the home path of catch2")
    ENDIF()
    FIND_FILE(CATCH2_HEADER
-             catch_test_macros.hpp 
+             catch_test_macros.hpp
              PATHS ${MOCKCPP_XUNIT_HOME}/catch2
-             NO_DEFAULT_PATH 
-             NO_CMAKE_ENVIRONMENT_PATH 
-             NO_CMAKE_PATH 
-             NO_SYSTEM_ENVIRONMENT_PATH 
+             NO_DEFAULT_PATH
+             NO_CMAKE_ENVIRONMENT_PATH
+             NO_CMAKE_PATH
+             NO_SYSTEM_ENVIRONMENT_PATH
              NO_CMAKE_SYSTEM_PATH)
    IF(NOT EXISTS ${CATCH2_HEADER})
       MESSAGE(FATAL_ERROR "Can't find file catch_test_macros.hpp, please specify MOCKCPP_XUNIT_HOME as the home path of catch2 correctly.")
@@ -259,30 +260,30 @@ ELSE()
 ENDIF()
 
 IF(MSVC OR MINGW)
-   SET(MOCKCPP_SRCS 
-       ${MOCKCPP_SRCS} 
+   SET(MOCKCPP_SRCS
+       ${MOCKCPP_SRCS}
        WinCodeModifier.cpp
-   ) 
+   )
 ELSE(MSVC OR MINGW)
-   SET(MOCKCPP_SRCS 
-       ${MOCKCPP_SRCS} 
+   SET(MOCKCPP_SRCS
+       ${MOCKCPP_SRCS}
        UnixCodeModifier.cpp
    )
 ENDIF(MSVC OR MINGW)
 ######################################################
 SET(MOCKCPP_HEADERS_PATH ${MOCKCPP_SRC_ROOT}/include/mockcpp)
 
-SET(MOCKCPP_VTBL_RELATED_HEADERS 
-    ${MOCKCPP_HEADERS_PATH}/DelegatedMethodGetDef.h 
-    ${MOCKCPP_HEADERS_PATH}/DelegatedMethodGetByVptrDef.h 
-    ${MOCKCPP_HEADERS_PATH}/DestructorAddrGetterDef.h 
+SET(MOCKCPP_VTBL_RELATED_HEADERS
+    ${MOCKCPP_HEADERS_PATH}/DelegatedMethodGetDef.h
+    ${MOCKCPP_HEADERS_PATH}/DelegatedMethodGetByVptrDef.h
+    ${MOCKCPP_HEADERS_PATH}/DestructorAddrGetterDef.h
     ${MOCKCPP_HEADERS_PATH}/MethodIndiceCheckerDef.h
     ${MOCKCPP_HEADERS_PATH}/DefaultMethodAddrGetterDef.h
 )
 
 SET(MOCKCPP_ARG_RELATED_HEADER_FILES
-    ${MOCKCPP_HEADERS_PATH}/DelegatedMethodDef.h 
-    ${MOCKCPP_HEADERS_PATH}/ArgumentsListDef.h  
+    ${MOCKCPP_HEADERS_PATH}/DelegatedMethodDef.h
+    ${MOCKCPP_HEADERS_PATH}/ArgumentsListDef.h
     ${MOCKCPP_HEADERS_PATH}/MethodTypeTraitsDef.h
 )
 

--- a/src/CallerMatcher.cpp
+++ b/src/CallerMatcher.cpp
@@ -28,14 +28,16 @@ CallerMatcher::CallerMatcher(const std::string& name)
 }
 
 ///////////////////////////////////////////////////////////
-bool CallerMatcher::matches(const Invocation& inv) const 
+bool CallerMatcher::matches(const Invocation& inv) const
 {
+    (void)inv;
     return inv.getNameOfCaller() == nameOfCaller;
 }
 
 ///////////////////////////////////////////////////////////
 void CallerMatcher::increaseInvoked(const Invocation& inv)
 {
+    (void)inv;
 }
 
 ///////////////////////////////////////////////////////////
@@ -54,4 +56,3 @@ std::string CallerMatcher::toString() const
 }
 
 MOCKCPP_NS_END
-

--- a/src/DefaultMatcher.cpp
+++ b/src/DefaultMatcher.cpp
@@ -21,14 +21,16 @@
 MOCKCPP_NS_START
 
 ///////////////////////////////////////////////////////////
-bool DefaultMatcher::matches(const Invocation& inv) const 
+bool DefaultMatcher::matches(const Invocation& inv) const
 {
+    (void)inv;
     return true;
 }
 
 ///////////////////////////////////////////////////////////
 void DefaultMatcher::increaseInvoked(const Invocation& inv)
 {
+    (void)inv;
 }
 
 ///////////////////////////////////////////////////////////
@@ -43,4 +45,3 @@ std::string DefaultMatcher::toString() const
 }
 
 MOCKCPP_NS_END
-

--- a/src/IgnoreResultHandlerFactory.cpp
+++ b/src/IgnoreResultHandlerFactory.cpp
@@ -28,10 +28,13 @@ ResultHandler* IgnoreResultHandlerFactory::create(
           , const std::string& expectedTypeString
           , const SelfDescribe* selfDescriber)
 {
-    return new IgnoreResultHandler();
+   (void)isCastable;
+   (void)expectedTypeInfo;
+   (void)expectedTypeString;
+   (void)selfDescriber;
+   return new IgnoreResultHandler();
 }
 
 ///////////////////////////////////////////////////////////
 
 MOCKCPP_NS_END
-

--- a/src/IgnoreResultHandlerFactory.cpp
+++ b/src/IgnoreResultHandlerFactory.cpp
@@ -28,11 +28,11 @@ ResultHandler* IgnoreResultHandlerFactory::create(
           , const std::string& expectedTypeString
           , const SelfDescribe* selfDescriber)
 {
-   (void)isCastable;
-   (void)expectedTypeInfo;
-   (void)expectedTypeString;
-   (void)selfDescriber;
-   return new IgnoreResultHandler();
+    (void)isCastable;
+    (void)expectedTypeInfo;
+    (void)expectedTypeString;
+    (void)selfDescriber;
+    return new IgnoreResultHandler();
 }
 
 ///////////////////////////////////////////////////////////

--- a/src/InvocationMocker.cpp
+++ b/src/InvocationMocker.cpp
@@ -91,7 +91,7 @@ InvocationMockerImpl::toString() const
     {
       ss << "\n" << space() << id->toString();
     }
-   
+
     ss << ";";
 
     return ss.str();
@@ -155,7 +155,7 @@ InvocationMockerImpl::matches(const Invocation& inv) const
 
 ///////////////////////////////////////////////////////////
 void
-InvocationMockerImpl::increaseInvoked(const Invocation& inv) 
+InvocationMockerImpl::increaseInvoked(const Invocation& inv)
 {
     for (Iterator i = matchers.begin(); i != matchers.end(); ++i)
     {
@@ -175,7 +175,7 @@ InvocationMockerImpl::invoke(const Invocation& inv)
     if (stub != 0)
     {
       return stub->invoke(inv);
-    } 
+    }
 
     return getVoidAny();
 }
@@ -220,13 +220,13 @@ bool InvocationMocker::hasBeenInvoked(void) const
 }
 
 ///////////////////////////////////////////////////////////
-void InvocationMocker::addStub(Stub* stub) 
+void InvocationMocker::addStub(Stub* stub)
 {
     This->stubs.addStub(stub);
 }
 
 ///////////////////////////////////////////////////////////
-const InvocationId* const InvocationMocker::getId(void) const
+const InvocationId* InvocationMocker::getId(void) const
 {
     return This->id;
 }
@@ -274,4 +274,3 @@ void InvocationMocker::verify()
 ///////////////////////////////////////////////////////////
 
 MOCKCPP_NS_END
-

--- a/src/InvocationTimesMatcher.cpp
+++ b/src/InvocationTimesMatcher.cpp
@@ -41,6 +41,7 @@ void InvocationTimesMatcher::setInvokedTimesReader(InvokedTimesReader* reader)
 /////////////////////////////////////////////////////////////////////
 void InvocationTimesMatcher::increaseInvoked(const Invocation& inv)
 {
+    (void)inv;
 }
 
 /////////////////////////////////////////////////////////////////////
@@ -50,5 +51,3 @@ unsigned int InvocationTimesMatcher::getInvokedTimes() const
 }
 
 MOCKCPP_NS_END
-
-

--- a/src/InvokedAtLeast.cpp
+++ b/src/InvokedAtLeast.cpp
@@ -31,6 +31,7 @@ InvokedAtLeast::InvokedAtLeast(const unsigned int times)
 ///////////////////////////////////////////////////////
 bool InvokedAtLeast::matches(const Invocation& inv) const
 {
+   (void)inv;
 	return true;
 }
 
@@ -53,10 +54,8 @@ void InvokedAtLeast::verify(void)
         << " times, but it's actually invoked " << getInvokedTimes() << " times";
 
     MOCKCPP_ASSERT_TRUE_MESSAGE(
-			"Invoked too few times" 
+			"Invoked too few times"
          , getInvokedTimes() >= lowLimit);
 }
 
 MOCKCPP_NS_END
-
-

--- a/src/InvokedAtMost.cpp
+++ b/src/InvokedAtMost.cpp
@@ -30,15 +30,18 @@ InvokedAtMost::InvokedAtMost(const unsigned int times)
 ///////////////////////////////////////////////////////
 bool InvokedAtMost::matches(const Invocation& inv) const
 {
+    (void)inv;
 	return true;
 }
 
 ///////////////////////////////////////////////////////
 void InvokedAtMost::increaseInvoked(const Invocation& inv)
 {
+    (void)inv;
+
     oss_t oss;
 
-    oss << "Expected at most " << highLimit 
+    oss << "Expected at most " << highLimit
         << " times, but you are trying to invoke more than that.";
 
     MOCKCPP_ASSERT_TRUE_MESSAGE(
@@ -61,8 +64,8 @@ void InvokedAtMost::verify(void)
 // We won't need to verify it here, it was checked at runtime.
 #if 0
     oss_t oss;
-    
-    oss << "Expected at most " << highLimit 
+
+    oss << "Expected at most " << highLimit
         << " times, but it's actually invoked " << getInvokedTimes() << " times";
 
     MOCKCPP_ASSERT_TRUE_MESSAGE(
@@ -72,5 +75,3 @@ void InvokedAtMost::verify(void)
 }
 
 MOCKCPP_NS_END
-
-

--- a/src/InvokedExactly.cpp
+++ b/src/InvokedExactly.cpp
@@ -31,8 +31,8 @@ InvokedExactly::InvokedExactly(const unsigned int times)
 /////////////////////////////////////////////////////////
 bool InvokedExactly::matches(const Invocation& inv) const
 {
-
-    return true;
+   (void)inv;
+   return true;
 }
 
 /////////////////////////////////////////////////////////
@@ -51,8 +51,8 @@ void InvokedExactly::verify(void)
 {
 	 oss_t oss;
 
-    oss << "Expected invoking exactly " << expectedInvokedTimes 
-        << " times, but it's actually invoked " << getInvokedTimes() 
+    oss << "Expected invoking exactly " << expectedInvokedTimes
+        << " times, but it's actually invoked " << getInvokedTimes()
         << " times.";
 
     MOCKCPP_ASSERT_TRUE_MESSAGE(
@@ -61,5 +61,3 @@ void InvokedExactly::verify(void)
 }
 
 MOCKCPP_NS_END
-
-

--- a/src/InvokedExactly.cpp
+++ b/src/InvokedExactly.cpp
@@ -31,8 +31,8 @@ InvokedExactly::InvokedExactly(const unsigned int times)
 /////////////////////////////////////////////////////////
 bool InvokedExactly::matches(const Invocation& inv) const
 {
-   (void)inv;
-   return true;
+    (void)inv;
+    return true;
 }
 
 /////////////////////////////////////////////////////////

--- a/src/InvokedOnce.cpp
+++ b/src/InvokedOnce.cpp
@@ -29,12 +29,15 @@ InvokedOnce::InvokedOnce()
 ///////////////////////////////////////////////////////
 bool InvokedOnce::matches(const Invocation& inv) const
 {
+    (void)inv;
     return true;
 }
 
 ///////////////////////////////////////////////////////
 void InvokedOnce::increaseInvoked(const Invocation& inv)
 {
+    (void)inv;
+
     oss_t oss;
 
     oss << "Invocation is expected only once(), but you are trying to "
@@ -42,7 +45,6 @@ void InvokedOnce::increaseInvoked(const Invocation& inv)
 
     MOCKCPP_ASSERT_TRUE_MESSAGE(
          oss.str(), getInvokedTimes() < 1);
-   
 }
 ///////////////////////////////////////////////////////
 std::string
@@ -64,5 +66,3 @@ void InvokedOnce::verify(void)
 }
 
 MOCKCPP_NS_END
-
-

--- a/src/InvokedTimesMatcher.cpp
+++ b/src/InvokedTimesMatcher.cpp
@@ -36,12 +36,14 @@ InvokedTimesMatcher::~InvokedTimesMatcher()
 ///////////////////////////////////////////////////////////////////////
 bool InvokedTimesMatcher::matches(const Invocation& inv) const
 {
+    (void)inv;
     return true;
 }
 
 ///////////////////////////////////////////////////////////////////////
 void InvokedTimesMatcher::increaseInvoked(const Invocation& inv)
 {
+    (void)inv;
     invokedTimesRecorder->increaseInvoked();
 }
 
@@ -63,4 +65,3 @@ void InvokedTimesMatcher::verify()
 ///////////////////////////////////////////////////////////////////////
 
 MOCKCPP_NS_END
-

--- a/src/JmpOnlyApiHook.h
+++ b/src/JmpOnlyApiHook.h
@@ -33,7 +33,7 @@ struct JmpOnlyApiHook
     ~JmpOnlyApiHook();
 
 private:
-    JmpOnlyApiHookImpl* This;;
+    JmpOnlyApiHookImpl* This;
 };
 
 MOCKCPP_NS_END

--- a/src/MismatchResultHandler.cpp
+++ b/src/MismatchResultHandler.cpp
@@ -39,7 +39,8 @@ MismatchResultHandler::MismatchResultHandler(
 ////////////////////////////////////////////////////////////////
 bool MismatchResultHandler::matches(const Any& result) const
 {
-      return !isCastable;
+    (void)result;
+    return !isCastable;
 }
 
 ////////////////////////////////////////////////////////////////
@@ -58,4 +59,3 @@ const Any& MismatchResultHandler::getResult(const Any& result) const
 }
 
 MOCKCPP_NS_END
-

--- a/src/NormalResultHandler.cpp
+++ b/src/NormalResultHandler.cpp
@@ -29,8 +29,8 @@ NormalResultHandler::NormalResultHandler(bool castable)
 ///////////////////////////////////////////////////////////////////////////
 bool NormalResultHandler::matches(const Any& result) const
 {
-   (void)result;
-   return isCastable;
+    (void)result;
+    return isCastable;
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/NormalResultHandler.cpp
+++ b/src/NormalResultHandler.cpp
@@ -29,16 +29,17 @@ NormalResultHandler::NormalResultHandler(bool castable)
 ///////////////////////////////////////////////////////////////////////////
 bool NormalResultHandler::matches(const Any& result) const
 {
-    return isCastable;
+   (void)result;
+   return isCastable;
 }
 
 ///////////////////////////////////////////////////////////////////////////
 const Any& NormalResultHandler::getResult(const Any& result) const
 {
-    return result;
+   (void)result;
+   return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////
 
 MOCKCPP_NS_END
-

--- a/src/NormalResultHandlerFactory.cpp
+++ b/src/NormalResultHandlerFactory.cpp
@@ -27,10 +27,10 @@ ResultHandler* NormalResultHandlerFactory::create(
           , const std::string& expectedTypeString
           , const SelfDescribe* selfDescriber)
 {
-   (void)expectedTypeInfo;
-   (void)expectedTypeString;
-   (void)selfDescriber;
-   return new NormalResultHandler(isCastable);
+    (void)expectedTypeInfo;
+    (void)expectedTypeString;
+    (void)selfDescriber;
+    return new NormalResultHandler(isCastable);
 }
 
 ///////////////////////////////////////////////////////////

--- a/src/NormalResultHandlerFactory.cpp
+++ b/src/NormalResultHandlerFactory.cpp
@@ -27,10 +27,12 @@ ResultHandler* NormalResultHandlerFactory::create(
           , const std::string& expectedTypeString
           , const SelfDescribe* selfDescriber)
 {
-    return new NormalResultHandler(isCastable);
+   (void)expectedTypeInfo;
+   (void)expectedTypeString;
+   (void)selfDescriber;
+   return new NormalResultHandler(isCastable);
 }
 
 ///////////////////////////////////////////////////////////
 
 MOCKCPP_NS_END
-

--- a/src/ReturnObjectList.cpp
+++ b/src/ReturnObjectList.cpp
@@ -70,9 +70,10 @@ std::string ReturnObjectListImpl::toString() const
 ///////////////////////////////////////////////////////
 unsigned int ReturnObjectListImpl::numberOfValidObjects() const
 {
-    for (size_t i = objects.size()-1; i >= 0; i--)
+    for (size_t i = objects.size()-1; ; i--)
     {
-      if(!objects[i].empty()) return (unsigned int)(i+1);
+      if (!objects[i].empty()) return (unsigned int)(i+1);
+      if (i == 0) break;
     }
 
     return 0;
@@ -90,7 +91,7 @@ Any& ReturnObjectListImpl::invoke()
     {
       return objects[firstUnused++];
     }
-    
+
     MOCKCPP_FAIL("All objects has been returned");
 
     return getEmptyAny();
@@ -100,18 +101,18 @@ Any& ReturnObjectListImpl::invoke()
 #define STORE_OBJECTS(i) This->objects.push_back(o##i)
 
 ReturnObjectList::ReturnObjectList(
-                      const Any& o1 
-                    , const Any& o2 
+                      const Any& o1
+                    , const Any& o2
                     , const Any& o3
-                    , const Any& o4 
+                    , const Any& o4
                     , const Any& o5
-                    , const Any& o6 
+                    , const Any& o6
                     , const Any& o7
                     , const Any& o8
-                    , const Any& o9 
-                    , const Any& o10 
-                    , const Any& o11 
-                    , const Any& o12 
+                    , const Any& o9
+                    , const Any& o10
+                    , const Any& o11
+                    , const Any& o12
     ) : This(new ReturnObjectListImpl)
 {
     STORE_OBJECTS(1);
@@ -153,7 +154,7 @@ std::string ReturnObjectList::toString(void) const
 ///////////////////////////////////////////////////
 const std::type_info& ReturnObjectList::type() const
 {
-    return This->type();   
+    return This->type();
 }
 
 ///////////////////////////////////////////////////
@@ -164,4 +165,3 @@ bool ReturnObjectList::isCompleted() const
 ///////////////////////////////////////////////////
 
 MOCKCPP_NS_END
-

--- a/src/StubsMatcher.cpp
+++ b/src/StubsMatcher.cpp
@@ -21,14 +21,16 @@
 MOCKCPP_NS_START
 
 ///////////////////////////////////////////////////////////
-bool StubsMatcher::matches(const Invocation& inv) const 
+bool StubsMatcher::matches(const Invocation& inv) const
 {
+    (void)inv;
     return true;
 }
 
 ///////////////////////////////////////////////////////////
 void StubsMatcher::increaseInvoked(const Invocation& inv)
 {
+    (void)inv;
 }
 
 ///////////////////////////////////////////////////////////
@@ -43,4 +45,3 @@ std::string StubsMatcher::toString() const
 }
 
 MOCKCPP_NS_END
-

--- a/src/TestFailureMatcher.cpp
+++ b/src/TestFailureMatcher.cpp
@@ -35,7 +35,7 @@ bool TestFailureMatcher::matches(const Invocation& inv) const
 //////////////////////////////////////////////////////////////////////
 void TestFailureMatcher::increaseInvoked(const Invocation& inv)
 {
-    (void)inv;  
+    (void)inv;
     MOCKCPP_FAIL(msg);
 }
 

--- a/src/TestFailureMatcher.cpp
+++ b/src/TestFailureMatcher.cpp
@@ -28,12 +28,14 @@ TestFailureMatcher::TestFailureMatcher(const std::string& m, const std::string& 
 //////////////////////////////////////////////////////////////////////
 bool TestFailureMatcher::matches(const Invocation& inv) const
 {
+    (void)inv;
     return true;
 }
 
 //////////////////////////////////////////////////////////////////////
-void TestFailureMatcher::increaseInvoked(const Invocation& inv) 
+void TestFailureMatcher::increaseInvoked(const Invocation& inv)
 {
+    (void)inv;  
     MOCKCPP_FAIL(msg);
 }
 
@@ -49,5 +51,3 @@ void TestFailureMatcher::verify(void)
 }
 
 MOCKCPP_NS_END
-
-

--- a/src/TypelessConstraintAdapter.cpp
+++ b/src/TypelessConstraintAdapter.cpp
@@ -51,8 +51,8 @@ TypelessConstraintAdapter::~TypelessConstraintAdapter()
 bool
 TypelessConstraintAdapter::eval(const RefAny& p) const
 {
-   (void)p; 
-   return This->typelessConstraint->eval();
+    (void)p;
+    return This->typelessConstraint->eval();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/TypelessConstraintAdapter.cpp
+++ b/src/TypelessConstraintAdapter.cpp
@@ -44,14 +44,15 @@ TypelessConstraintAdapter::TypelessConstraintAdapter(TypelessConstraint* tc)
 //////////////////////////////////////////////////////////////////////////
 TypelessConstraintAdapter::~TypelessConstraintAdapter()
 {
-    delete This;
+   delete This;
 }
 
 //////////////////////////////////////////////////////////////////////////
 bool
 TypelessConstraintAdapter::eval(const RefAny& p) const
 {
-    return This->typelessConstraint->eval();
+   (void)p; 
+   return This->typelessConstraint->eval();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -67,4 +68,3 @@ std::string TypelessConstraintAdapter::toString() const
 }
 
 MOCKCPP_NS_END
-

--- a/src/TypelessStubAdapter.cpp
+++ b/src/TypelessStubAdapter.cpp
@@ -38,6 +38,7 @@ bool TypelessStubAdapter::isCompleted() const
 ////////////////////////////////////////////////////////
 Any& TypelessStubAdapter::invoke(const Invocation& inv)
 {
+   (void)inv;  
 	return stub->invoke();
 }
 
@@ -50,5 +51,3 @@ std::string TypelessStubAdapter::toString() const
 ////////////////////////////////////////////////////////
 
 MOCKCPP_NS_END
-
-

--- a/src/TypelessStubAdapter.cpp
+++ b/src/TypelessStubAdapter.cpp
@@ -38,7 +38,7 @@ bool TypelessStubAdapter::isCompleted() const
 ////////////////////////////////////////////////////////
 Any& TypelessStubAdapter::invoke(const Invocation& inv)
 {
-   (void)inv;  
+   (void)inv;
 	return stub->invoke();
 }
 

--- a/src/VirtualTableUtils.cpp
+++ b/src/VirtualTableUtils.cpp
@@ -36,7 +36,7 @@ namespace
 #endif
    const unsigned int SLOTS_PER_VTBL = MOCKCPP_MAX_VTBL_SIZE + EXTRA_VTBL_SLOT;
 
-   unsigned int times = 0;
+   // unsigned int times = 0;
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -49,6 +49,8 @@ void** createVtbls(unsigned int numberOfVptr)
 
 void freeVtbls(void** vtbl, unsigned int numberOfVptr)
 {
+   (void)numberOfVptr;
+
 #if defined(_MSC_VER)
 	 RTTIClassHierarchyDescriptor* desc = 0;
    for(unsigned int i=0; i<numberOfVptr; i++)
@@ -77,7 +79,8 @@ unsigned int getRealVtblIndex(unsigned int indexOfVptr, unsigned int indexOfVtbl
 
 ///////////////////////////////////////////////////////////////////////
 void initializeVtbls(void** vptr, void**vtbl, unsigned int numberOfVptr, const std::type_info& info, bool hasRtti)
-{  
+{
+   (void)hasRtti;
 
 #if defined(_MSC_VER)
 

--- a/src/VoidResultHandler.cpp
+++ b/src/VoidResultHandler.cpp
@@ -46,6 +46,8 @@ bool VoidResultHandler::matches(const Any& result) const
 /////////////////////////////////////////////////////////
 const Any& VoidResultHandler::getResult(const Any& result) const
 {
+    (void)result;
+
     oss_t oss;
 
     oss << "You need to specify a return value by using will(...) in \n"
@@ -60,4 +62,3 @@ const Any& VoidResultHandler::getResult(const Any& result) const
 /////////////////////////////////////////////////////////
 
 MOCKCPP_NS_END
-

--- a/src/VoidResultHandlerFactory.cpp
+++ b/src/VoidResultHandlerFactory.cpp
@@ -28,9 +28,9 @@ ResultHandler* VoidResultHandlerFactory::create(
           , const std::string& expectedTypeString
           , const SelfDescribe* selfDescriber)
 {
-    return new VoidResultHandler(expectedTypeInfo, expectedTypeString, selfDescriber);
+   (void)isCastable;
+   return new VoidResultHandler(expectedTypeInfo, expectedTypeString, selfDescriber);
 }
 
 
 MOCKCPP_NS_END
-

--- a/src/VoidResultHandlerFactory.cpp
+++ b/src/VoidResultHandlerFactory.cpp
@@ -28,8 +28,8 @@ ResultHandler* VoidResultHandlerFactory::create(
           , const std::string& expectedTypeString
           , const SelfDescribe* selfDescriber)
 {
-   (void)isCastable;
-   return new VoidResultHandler(expectedTypeInfo, expectedTypeString, selfDescriber);
+    (void)isCastable;
+    return new VoidResultHandler(expectedTypeInfo, expectedTypeString, selfDescriber);
 }
 
 

--- a/tests/3rdparty/testngpp/Makefile
+++ b/tests/3rdparty/testngpp/Makefile
@@ -27,19 +27,26 @@ cmake_force:
 # Set environment variables for the build.
 
 # The shell in which to execute make rules.
-SHELL = /bin/sh
+SHELL := /bin/sh
 
 # The CMake executable.
-CMAKE_COMMAND = /usr/local/bin/cmake
+CMAKE_COMMAND := $(shell which cmake)
 
 # The command to remove a file.
-RM = /usr/local/bin/cmake -E remove -f
+RM := $(CMAKE_COMMAND) -E remove -f
+
+# The top-level source directory.
+SRC_ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
+TEST_NG_PP_SRC_ROOT_DIR := $(realpath "$(SRC_ROOT_DIR)/../../../../test-ng-pp")
 
 # The top-level source directory on which CMake was run.
-CMAKE_SOURCE_DIR = /home/topcoder/test-ng-pp
+# CMAKE_SOURCE_DIR = /home/topcoder/test-ng-pp
+CMAKE_SOURCE_DIR := $(TEST_NG_PP_SRC_ROOT_DIR)
 
 # The top-level build directory on which CMake was run.
-CMAKE_BINARY_DIR = /home/topcoder/test-ng-pp
+# CMAKE_BINARY_DIR = /home/topcoder/test-ng-pp
+CMAKE_BINARY_DIR := $(TEST_NG_PP_SRC_ROOT_DIR)
 
 #=============================================================================
 # Targets provided globally by CMake.
@@ -343,4 +350,3 @@ help:
 cmake_check_build_system:
 	$(CMAKE_COMMAND) -H$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 0
 .PHONY : cmake_check_build_system
-

--- a/tests/3rdparty/testngpp/include/mem_checker/fixed_mem_pool.h
+++ b/tests/3rdparty/testngpp/include/mem_checker/fixed_mem_pool.h
@@ -209,7 +209,7 @@ inline int fixed_mem_pool<_Tp>::get_alloc_count()
 template <class _Tp>
 inline bool fixed_mem_pool<_Tp>::is_initialized()
 {
-    return _S_mem_pool_ptr != NULL;;
+    return _S_mem_pool_ptr != NULL;
 }
 
 /**

--- a/tests/3rdparty/testngpp/tests/3rdparty/mockcpp/include/mockcpp/ApiHook.h
+++ b/tests/3rdparty/testngpp/tests/3rdparty/mockcpp/include/mockcpp/ApiHook.h
@@ -32,7 +32,7 @@ struct ApiHook
     ~ApiHook();
 
 private:
-    ApiHookImpl* This;;
+    ApiHookImpl* This;
 };
 
 MOCKCPP_NS_END

--- a/tests/3rdparty/testngpp/tests/3rdparty/mockcpp/src/JmpOnlyApiHook.h
+++ b/tests/3rdparty/testngpp/tests/3rdparty/mockcpp/src/JmpOnlyApiHook.h
@@ -33,7 +33,7 @@ struct JmpOnlyApiHook
     ~JmpOnlyApiHook();
 
 private:
-    JmpOnlyApiHookImpl* This;;
+    JmpOnlyApiHookImpl* This;
 };
 
 MOCKCPP_NS_END

--- a/tests/3rdparty/testngpp/tests/3rdparty/testngppst/include/mem_checker/fixed_mem_pool.h
+++ b/tests/3rdparty/testngpp/tests/3rdparty/testngppst/include/mem_checker/fixed_mem_pool.h
@@ -209,7 +209,7 @@ inline int fixed_mem_pool<_Tp>::get_alloc_count()
 template <class _Tp>
 inline bool fixed_mem_pool<_Tp>::is_initialized()
 {
-    return _S_mem_pool_ptr != NULL;;
+    return _S_mem_pool_ptr != NULL;
 }
 
 /**


### PR DESCRIPTION
Fix compiler warnings for:
- unused variables.
- reorder member initialization.
- type qualifiers ignored on function return type.