### PR TITLE
fix: support C function mocking on ARM architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ tests/ut/TestApiHookBase.cpp
 tests/ut/TestChainableMockMethodContainer.cpp
 tests/ut/TestChainableObject.cpp
 tests/ut/TestCheck.cpp
+tests/ut/TestCodeModifier.cpp
 tests/ut/TestConstraintSet.cpp
 tests/ut/TestDelegatedMethod.cpp
 tests/ut/TestDestructorChecker.cpp

--- a/docs/BuildGuide
+++ b/docs/BuildGuide
@@ -9,6 +9,8 @@ as a user
 	The other way:
 	sudo make install 
 	and then use /usr/local/include/mockcpp and /usr/local/lib/libmockcpp.a.
+	When linking libmockcpp.a directly on Linux/AArch64 with glibc older than 2.34,
+	add -ldl. CMake builds propagate ${CMAKE_DL_LIBS} through the in-tree target.
 	if the test framework you use is not testngpp, such as cpputest, gtest etc. , you should run these commands: (there is a $xunit_home/include/gtest/gtest.h file)
 	cmake -DMOCKCPP_XUNIT=gtest -DMOCKCPP_XUNIT_HOME=$xunit_home ../mockcpp/mockcpp
 	make

--- a/include/mockcpp/GnuMethodInfoReader.h
+++ b/include/mockcpp/GnuMethodInfoReader.h
@@ -18,6 +18,7 @@
 #define __MOCKCPP_GNU_METHOD_INFO_READER_H
 
 #include <algorithm>
+#include <stddef.h>
 #include <mockcpp/mockcpp.h>
 
 #include <mockcpp/OutputStringStream.h>
@@ -32,11 +33,21 @@ struct GnuMethodDescription
 {
    union {
 	  void* addr;
-     int index;
+     ptrdiff_t index;
    }u;
  
-   int delta;
+   ptrdiff_t delta;
 };
+
+inline bool gnuMethodIsVirtual(const GnuMethodDescription& method)
+{
+#if defined(__aarch64__) || defined(__arm__)
+   // Arm's GNU C++ ABI stores the virtual bit in adj, not in ptr.
+   return (method.delta & 1) != 0;
+#else
+   return (method.u.index & 1) != 0;
+#endif
+}
 
 ///////////////////////////////////////////////////////////
 template <typename Method>
@@ -54,12 +65,12 @@ void* getAddrOfMethod(Method input)
 	m.method = input;
 
    oss_t oss;
-   oss << "Method address should be even, please make sure the method "
-       << TypeString<Method>::value() << " is NOT a virtual method";
+   oss << "Expected a non-virtual method, but "
+       << TypeString<Method>::value() << " is virtual";
  
 	MOCKCPP_ASSERT_TRUE(
 		oss.str(),
-	   !(m.desc.u.index%2));
+	   !gnuMethodIsVirtual(m.desc));
 
 
    return m.desc.u.addr;
@@ -74,12 +85,12 @@ GnuMethodDescription getGnuDescOfVirtualMethod(Method input)
 	m.method = input;
 
    oss_t oss;
-   oss << "Virtual method address should be odd, please make sure the method "
-       << TypeString<Method>::value() << " is a virtual method";
+   oss << "Expected a virtual method, but "
+       << TypeString<Method>::value() << " is not virtual";
  
 	MOCKCPP_ASSERT_TRUE(
 		oss.str(),
-	   (m.desc.u.index%2));
+	   gnuMethodIsVirtual(m.desc));
 
 	return m.desc;
 }
@@ -88,17 +99,33 @@ GnuMethodDescription getGnuDescOfVirtualMethod(Method input)
 template <typename C, typename Method>
 unsigned int getIndexOfMethod(Method method)
 {
-   return (getGnuDescOfVirtualMethod<C, Method>(method).u.index - 1)/sizeof(void*);
+   const GnuMethodDescription desc =
+      getGnuDescOfVirtualMethod<C, Method>(method);
+#if defined(__aarch64__) || defined(__arm__)
+   return static_cast<unsigned int>(
+      desc.u.index/static_cast<ptrdiff_t>(sizeof(void*)));
+#else
+   return static_cast<unsigned int>(
+      (desc.u.index - 1)/static_cast<ptrdiff_t>(sizeof(void*)));
+#endif
 }
 
 ///////////////////////////////////////////////////////////
 template <typename C, typename Method>
 unsigned int getDeltaOfMethod(Method method)
 {
-   return getGnuDescOfVirtualMethod<C, Method>(method).delta/sizeof(void*);
+   const GnuMethodDescription desc =
+      getGnuDescOfVirtualMethod<C, Method>(method);
+#if defined(__aarch64__) || defined(__arm__)
+   const ptrdiff_t adjustment = (desc.delta - 1)/2;
+   return static_cast<unsigned int>(
+      adjustment/static_cast<ptrdiff_t>(sizeof(void*)));
+#else
+   return static_cast<unsigned int>(
+      desc.delta/static_cast<ptrdiff_t>(sizeof(void*)));
+#endif
 }
 
 MOCKCPP_NS_END
 
 #endif
-

--- a/include/mockcpp/JmpCode.h
+++ b/include/mockcpp/JmpCode.h
@@ -34,6 +34,8 @@ struct JmpCode
     void*  getCodeData() const;
     size_t getCodeSize() const;
     void*  getPatchAddress() const;
+    void markInstalled();
+    void markRestored();
 private:
 	JmpCodeImpl* This;
 };

--- a/include/mockcpp/JmpCode.h
+++ b/include/mockcpp/JmpCode.h
@@ -33,6 +33,7 @@ struct JmpCode
     
     void*  getCodeData() const;
     size_t getCodeSize() const;
+    void*  getPatchAddress() const;
 private:
 	JmpCodeImpl* This;
 };
@@ -40,4 +41,3 @@ private:
 MOCKCPP_NS_END
 
 #endif
-

--- a/src/AArch64PltResolver.cpp
+++ b/src/AArch64PltResolver.cpp
@@ -32,6 +32,7 @@
 #include <link.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #endif
 
@@ -110,22 +111,192 @@ bool isReadableExecutableRange(const void* address, size_t size)
    return query.found;
 }
 
-const void* dynamicAddress(const struct link_map* image, ElfW(Addr) value)
+bool rangeWithinSegment(uintptr_t segmentStart,
+                        uintptr_t segmentSize,
+                        uintptr_t address,
+                        size_t size)
 {
-   // Canonical PLT resolution is deliberately restricted to an ET_EXEC
-   // image with l_addr == 0, so its dynamic pointers are already absolute.
-   if(image->l_addr != 0)
+   if(address < segmentStart ||
+      size > segmentSize ||
+      address - segmentStart > segmentSize - size)
+   {
+      return false;
+   }
+
+   return true;
+}
+
+struct LoadedImageView
+{
+   LoadedImageView()
+      : loadBias(0)
+      , phdrs(0)
+      , phnum(0)
+      , dynamic(0)
+      , dynamicCount(0)
+   {
+   }
+
+   uintptr_t loadBias;
+   const ElfW(Phdr)* phdrs;
+   size_t phnum;
+   const ElfW(Dyn)* dynamic;
+   size_t dynamicCount;
+};
+
+bool imageContainsRange(const LoadedImageView& image,
+                        const void* address,
+                        size_t size,
+                        ElfW(Word) requiredFlags)
+{
+   if(address == 0 || size == 0)
+   {
+      return false;
+   }
+
+   const uintptr_t rangeAddress = reinterpret_cast<uintptr_t>(address);
+   for(size_t i = 0; i < image.phnum; ++i)
+   {
+      const ElfW(Phdr)& header = image.phdrs[i];
+      if(header.p_type != PT_LOAD ||
+         (header.p_flags & requiredFlags) != requiredFlags)
+      {
+         continue;
+      }
+
+      const uintptr_t offset = static_cast<uintptr_t>(header.p_vaddr);
+      if(image.loadBias > UINTPTR_MAX - offset)
+      {
+         continue;
+      }
+
+      const uintptr_t start = image.loadBias + offset;
+      const uintptr_t segmentSize = static_cast<uintptr_t>(header.p_memsz);
+      if(rangeWithinSegment(start, segmentSize, rangeAddress, size))
+      {
+         return true;
+      }
+   }
+
+   return false;
+}
+
+struct LoadedImageQuery
+{
+   LoadedImageQuery(const struct link_map* map, const void* value)
+      : image(map)
+      , address(reinterpret_cast<uintptr_t>(value))
+      , found(false)
+   {
+   }
+
+   const struct link_map* image;
+   uintptr_t address;
+   LoadedImageView view;
+   bool found;
+};
+
+int findLoadedImage(struct dl_phdr_info* info, size_t, void* data)
+{
+   LoadedImageQuery* query = static_cast<LoadedImageQuery*>(data);
+   if(static_cast<ElfW(Addr)>(info->dlpi_addr) != query->image->l_addr)
    {
       return 0;
    }
 
-   return reinterpret_cast<const void*>(static_cast<uintptr_t>(value));
+   bool containsAddress = false;
+   const ElfW(Phdr)* dynamicHeader = 0;
+   for(ElfW(Half) i = 0; i < info->dlpi_phnum; ++i)
+   {
+      const ElfW(Phdr)& header = info->dlpi_phdr[i];
+      const uintptr_t offset = static_cast<uintptr_t>(header.p_vaddr);
+      if(static_cast<uintptr_t>(info->dlpi_addr) > UINTPTR_MAX - offset)
+      {
+         continue;
+      }
+
+      const uintptr_t start =
+         static_cast<uintptr_t>(info->dlpi_addr) + offset;
+      if(header.p_type == PT_LOAD &&
+         rangeWithinSegment(start,
+                            static_cast<uintptr_t>(header.p_memsz),
+                            query->address,
+                            1))
+      {
+         containsAddress = true;
+      }
+      else if(header.p_type == PT_DYNAMIC)
+      {
+         if(dynamicHeader != 0)
+         {
+            return 0;
+         }
+         dynamicHeader = &header;
+      }
+   }
+
+   if(!containsAddress || dynamicHeader == 0 ||
+      dynamicHeader->p_filesz < sizeof(ElfW(Dyn)) ||
+      dynamicHeader->p_filesz > dynamicHeader->p_memsz ||
+      dynamicHeader->p_filesz % sizeof(ElfW(Dyn)) != 0)
+   {
+      return 0;
+   }
+
+   const uintptr_t dynamicOffset =
+      static_cast<uintptr_t>(dynamicHeader->p_vaddr);
+   const uintptr_t loadBias = static_cast<uintptr_t>(info->dlpi_addr);
+   if(loadBias > UINTPTR_MAX - dynamicOffset)
+   {
+      return 0;
+   }
+
+   query->view.loadBias = loadBias;
+   query->view.phdrs = info->dlpi_phdr;
+   query->view.phnum = info->dlpi_phnum;
+   query->view.dynamic = reinterpret_cast<const ElfW(Dyn)*>(
+      loadBias + dynamicOffset);
+   query->view.dynamicCount = static_cast<size_t>(
+      dynamicHeader->p_filesz / sizeof(ElfW(Dyn)));
+
+   if(query->view.dynamic != query->image->l_ld ||
+      !imageContainsRange(query->view,
+                          query->view.dynamic,
+                          static_cast<size_t>(dynamicHeader->p_filesz),
+                          PF_R))
+   {
+      return 0;
+   }
+
+   query->found = true;
+   return 1;
+}
+
+bool getLoadedImageView(const void* address,
+                        const struct link_map* image,
+                        LoadedImageView* view)
+{
+   LoadedImageQuery query(image, address);
+   ::dl_iterate_phdr(findLoadedImage, &query);
+   if(!query.found)
+   {
+      return false;
+   }
+
+   *view = query.view;
+   return true;
 }
 
 bool isMainExecutableImage(const Dl_info& info,
-                           const struct link_map* image)
+                           const struct link_map* image,
+                           const LoadedImageView& view)
 {
    if(info.dli_fbase == 0 || image == 0 || image->l_addr != 0)
+   {
+      return false;
+   }
+
+   if(!imageContainsRange(view, info.dli_fbase, sizeof(Elf64_Ehdr), PF_R))
    {
       return false;
    }
@@ -142,61 +313,383 @@ bool isMainExecutableImage(const Dl_info& info,
           header->e_machine == EM_AARCH64;
 }
 
-bool isUnversionedSymbol(const ElfW(Sym)* symbol,
-                         const struct link_map* image)
+struct DynamicTables
 {
-   if(image == 0 || image->l_ld == 0)
+   DynamicTables()
+      : symbolTable(0)
+      , symbolEntrySize(0)
+      , stringTable(0)
+      , stringTableSize(0)
+      , versionTable(0)
+      , versionNeeds(0)
+      , versionNeedCount(0)
+   {
+   }
+
+   const ElfW(Sym)* symbolTable;
+   size_t symbolEntrySize;
+   const char* stringTable;
+   size_t stringTableSize;
+   const ElfW(Half)* versionTable;
+   const ElfW(Verneed)* versionNeeds;
+   size_t versionNeedCount;
+};
+
+template <typename T>
+bool setUniqueValue(T* destination, bool* found, const T& value)
+{
+   if(*found && *destination != value)
    {
       return false;
    }
 
-   const ElfW(Sym)* symbolTable = 0;
-   const ElfW(Half)* versionTable = 0;
+   *destination = value;
+   *found = true;
+   return true;
+}
 
-   for(const ElfW(Dyn)* entry = image->l_ld;
-       entry->d_tag != DT_NULL;
-       ++entry)
+bool readDynamicTables(const LoadedImageView& image, DynamicTables* tables)
+{
+   // This resolver only accepts a non-PIE ET_EXEC image.  Its address-valued
+   // dynamic entries are therefore already absolute runtime addresses.
+   if(image.loadBias != 0)
    {
+      return false;
+   }
+
+   bool foundTerminator = false;
+   bool foundSymbolTable = false;
+   bool foundSymbolEntrySize = false;
+   bool foundStringTable = false;
+   bool foundStringTableSize = false;
+   bool foundVersionTable = false;
+   bool foundVersionNeeds = false;
+   bool foundVersionNeedCount = false;
+
+   for(size_t i = 0; i < image.dynamicCount; ++i)
+   {
+      const ElfW(Dyn)* entry = image.dynamic + i;
+      if(entry->d_tag == DT_NULL)
+      {
+         foundTerminator = true;
+         break;
+      }
+
       if(entry->d_tag == DT_SYMTAB)
       {
-         symbolTable = static_cast<const ElfW(Sym)*>(
-            dynamicAddress(image, entry->d_un.d_ptr));
+         const ElfW(Sym)* value = reinterpret_cast<const ElfW(Sym)*>(
+            static_cast<uintptr_t>(entry->d_un.d_ptr));
+         if(!setUniqueValue(&tables->symbolTable,
+                            &foundSymbolTable,
+                            value))
+         {
+            return false;
+         }
+      }
+      else if(entry->d_tag == DT_SYMENT)
+      {
+         const size_t value = static_cast<size_t>(entry->d_un.d_val);
+         if(!setUniqueValue(&tables->symbolEntrySize,
+                            &foundSymbolEntrySize,
+                            value))
+         {
+            return false;
+         }
+      }
+      else if(entry->d_tag == DT_STRTAB)
+      {
+         const char* value = reinterpret_cast<const char*>(
+            static_cast<uintptr_t>(entry->d_un.d_ptr));
+         if(!setUniqueValue(&tables->stringTable,
+                            &foundStringTable,
+                            value))
+         {
+            return false;
+         }
+      }
+      else if(entry->d_tag == DT_STRSZ)
+      {
+         const size_t value = static_cast<size_t>(entry->d_un.d_val);
+         if(!setUniqueValue(&tables->stringTableSize,
+                            &foundStringTableSize,
+                            value))
+         {
+            return false;
+         }
       }
 #ifdef DT_VERSYM
       else if(entry->d_tag == DT_VERSYM)
       {
-         versionTable = static_cast<const ElfW(Half)*>(
-            dynamicAddress(image, entry->d_un.d_ptr));
+         const ElfW(Half)* value = reinterpret_cast<const ElfW(Half)*>(
+            static_cast<uintptr_t>(entry->d_un.d_ptr));
+         if(!setUniqueValue(&tables->versionTable,
+                            &foundVersionTable,
+                            value))
+         {
+            return false;
+         }
       }
 #endif
+      else if(entry->d_tag == DT_VERNEED)
+      {
+         const ElfW(Verneed)* value =
+            reinterpret_cast<const ElfW(Verneed)*>(
+               static_cast<uintptr_t>(entry->d_un.d_ptr));
+         if(!setUniqueValue(&tables->versionNeeds,
+                            &foundVersionNeeds,
+                            value))
+         {
+            return false;
+         }
+      }
+      else if(entry->d_tag == DT_VERNEEDNUM)
+      {
+         const size_t value = static_cast<size_t>(entry->d_un.d_val);
+         if(!setUniqueValue(&tables->versionNeedCount,
+                            &foundVersionNeedCount,
+                            value))
+         {
+            return false;
+         }
+      }
    }
 
-   if(symbolTable == 0)
+   if(!foundTerminator ||
+      !foundSymbolTable || tables->symbolTable == 0 ||
+      !foundSymbolEntrySize ||
+      tables->symbolEntrySize != sizeof(ElfW(Sym)) ||
+      !foundStringTable || tables->stringTable == 0 ||
+      !foundStringTableSize || tables->stringTableSize == 0 ||
+      (foundVersionTable && tables->versionTable == 0) ||
+      foundVersionNeeds != foundVersionNeedCount ||
+      (foundVersionNeeds &&
+       (tables->versionNeeds == 0 || tables->versionNeedCount == 0)) ||
+      !imageContainsRange(image,
+                          tables->symbolTable,
+                          sizeof(*tables->symbolTable),
+                          PF_R) ||
+      !imageContainsRange(image,
+                          tables->stringTable,
+                          tables->stringTableSize,
+                          PF_R))
+   {
+      return false;
+   }
+
+   return true;
+}
+
+const char* boundedString(const DynamicTables& tables, size_t offset)
+{
+   if(offset >= tables.stringTableSize)
+   {
+      return 0;
+   }
+
+   const char* value = tables.stringTable + offset;
+   const size_t remaining = tables.stringTableSize - offset;
+   return ::memchr(value, '\0', remaining) == 0 ? 0 : value;
+}
+
+template <typename T>
+const T* checkedArrayElement(const T* array, size_t index)
+{
+   const uintptr_t start = reinterpret_cast<uintptr_t>(array);
+   if(index > (UINTPTR_MAX - start) / sizeof(T))
+   {
+      return 0;
+   }
+
+   return reinterpret_cast<const T*>(start + index * sizeof(T));
+}
+
+template <typename T, typename Base>
+const T* checkedRelativePointer(const Base* base, size_t offset)
+{
+   const uintptr_t start = reinterpret_cast<uintptr_t>(base);
+   if(start > UINTPTR_MAX - offset)
+   {
+      return 0;
+   }
+
+   return reinterpret_cast<const T*>(start + offset);
+}
+
+struct ImportedSymbolLookup
+{
+   ImportedSymbolLookup()
+      : name(0), version(0)
+   {
+   }
+
+   const char* name;
+   const char* version;
+};
+
+bool getImportedSymbolLookup(const ElfW(Sym)* symbol,
+                             const LoadedImageView& image,
+                             ImportedSymbolLookup* lookup)
+{
+   DynamicTables tables;
+   if(!readDynamicTables(image, &tables) ||
+      !imageContainsRange(image, symbol, sizeof(*symbol), PF_R))
    {
       return false;
    }
 
    const uintptr_t symbolAddress = reinterpret_cast<uintptr_t>(symbol);
-   const uintptr_t tableAddress = reinterpret_cast<uintptr_t>(symbolTable);
+   const uintptr_t tableAddress =
+      reinterpret_cast<uintptr_t>(tables.symbolTable);
    if(symbolAddress < tableAddress)
    {
       return false;
    }
 
    const uintptr_t byteOffset = symbolAddress - tableAddress;
-   if(byteOffset % sizeof(ElfW(Sym)) != 0)
+   if(byteOffset % tables.symbolEntrySize != 0)
    {
       return false;
    }
 
-   if(versionTable == 0)
+   lookup->name = boundedString(tables, symbol->st_name);
+   if(lookup->name == 0 || lookup->name[0] == '\0')
+   {
+      return false;
+   }
+
+   if(tables.versionTable == 0)
    {
       return true;
    }
 
-   const size_t symbolIndex = byteOffset / sizeof(ElfW(Sym));
-   const ElfW(Half) version = versionTable[symbolIndex] & 0x7fffU;
-   return version <= 1;
+   const size_t symbolIndex = byteOffset / tables.symbolEntrySize;
+   const ElfW(Half)* versionEntry =
+      checkedArrayElement(tables.versionTable, symbolIndex);
+   if(versionEntry == 0 ||
+      !imageContainsRange(image, versionEntry, sizeof(*versionEntry), PF_R))
+   {
+      return false;
+   }
+
+   const unsigned int versionIndex = *versionEntry & 0x7fffU;
+   if(versionIndex == VER_NDX_LOCAL || versionIndex == VER_NDX_GLOBAL)
+   {
+      return true;
+   }
+
+   if(tables.versionNeeds == 0 || tables.versionNeedCount == 0 ||
+      tables.versionNeedCount > 0x7fffU)
+   {
+      return false;
+   }
+
+   const ElfW(Verneed)* need = tables.versionNeeds;
+   const char* matchedVersion = 0;
+   size_t totalAuxiliaryCount = 0;
+   for(size_t needIndex = 0;
+       needIndex < tables.versionNeedCount;
+       ++needIndex)
+   {
+      if(!imageContainsRange(image, need, sizeof(*need), PF_R) ||
+         need->vn_version != VER_NEED_CURRENT || need->vn_cnt == 0 ||
+         need->vn_cnt > 0x7fffU ||
+         totalAuxiliaryCount > 0x7fffU - need->vn_cnt ||
+         need->vn_aux < sizeof(*need) ||
+         need->vn_aux % __alignof__(ElfW(Vernaux)) != 0)
+      {
+         return false;
+      }
+
+      const char* neededFile = boundedString(tables, need->vn_file);
+      if(neededFile == 0 || neededFile[0] == '\0')
+      {
+         return false;
+      }
+      totalAuxiliaryCount += need->vn_cnt;
+
+      const ElfW(Vernaux)* auxiliary =
+         checkedRelativePointer<ElfW(Vernaux)>(need, need->vn_aux);
+      if(auxiliary == 0)
+      {
+         return false;
+      }
+
+      for(ElfW(Half) auxiliaryIndex = 0;
+          auxiliaryIndex < need->vn_cnt;
+          ++auxiliaryIndex)
+      {
+         if(!imageContainsRange(image,
+                                auxiliary,
+                                sizeof(*auxiliary),
+                                PF_R))
+         {
+            return false;
+         }
+
+         const char* versionName =
+            boundedString(tables, auxiliary->vna_name);
+         if(versionName == 0 || versionName[0] == '\0')
+         {
+            return false;
+         }
+
+         if((auxiliary->vna_other & 0x7fffU) == versionIndex)
+         {
+            if(matchedVersion != 0)
+            {
+               return false;
+            }
+            matchedVersion = versionName;
+         }
+
+         if(auxiliaryIndex + 1 < need->vn_cnt)
+         {
+            if(auxiliary->vna_next < sizeof(*auxiliary) ||
+               auxiliary->vna_next % __alignof__(ElfW(Vernaux)) != 0)
+            {
+               return false;
+            }
+            auxiliary = checkedRelativePointer<ElfW(Vernaux)>(
+               auxiliary, auxiliary->vna_next);
+            if(auxiliary == 0)
+            {
+               return false;
+            }
+         }
+         else if(auxiliary->vna_next != 0)
+         {
+            return false;
+         }
+      }
+
+      if(needIndex + 1 < tables.versionNeedCount)
+      {
+         if(need->vn_next < sizeof(*need) ||
+            need->vn_next % __alignof__(ElfW(Verneed)) != 0)
+         {
+            return false;
+         }
+         need = checkedRelativePointer<ElfW(Verneed)>(need, need->vn_next);
+         if(need == 0)
+         {
+            return false;
+         }
+      }
+      else if(need->vn_next != 0)
+      {
+         return false;
+      }
+   }
+
+   lookup->version = matchedVersion;
+   return lookup->version != 0;
+}
+
+void* lookupRuntimeSymbol(void* handle, const ImportedSymbolLookup& lookup)
+{
+   return lookup.version == 0
+      ? ::dlsym(handle, lookup.name)
+      : ::dlvsym(handle, lookup.name, lookup.version);
 }
 
 bool beginsWithBti(const void* address)
@@ -279,20 +772,26 @@ AArch64PltResolution resolveCanonicalPltAddress(const void* address)
 
    Dl_info linkInfo;
    void* linkData = 0;
+   LoadedImageView sourceImageView;
+   ImportedSymbolLookup lookup;
    if(::dladdr1(address, &linkInfo, &linkData, RTLD_DL_LINKMAP) == 0 ||
-      linkData == 0 || linkInfo.dli_fbase != sourceInfo.dli_fbase ||
-      !isMainExecutableImage(
-         sourceInfo, static_cast<const struct link_map*>(linkData)) ||
-      !isUnversionedSymbol(symbol,
-                           static_cast<const struct link_map*>(linkData)))
+      linkData == 0 || linkInfo.dli_fbase != sourceInfo.dli_fbase)
    {
-      // dlsym() cannot express the exact relocation version without parsing
-      // the caller's version definition.  Do not guess for versioned imports.
+      return sourceFallback;
+   }
+
+   const struct link_map* sourceImage =
+      static_cast<const struct link_map*>(linkData);
+   if(!getLoadedImageView(address, sourceImage, &sourceImageView) ||
+      !isMainExecutableImage(sourceInfo, sourceImage, sourceImageView) ||
+      !getImportedSymbolLookup(symbol, sourceImageView, &lookup) ||
+      ::strcmp(lookup.name, sourceInfo.dli_sname) != 0)
+   {
       return sourceFallback;
    }
 
    ::dlerror();
-   void* resolved = ::dlsym(RTLD_NEXT, sourceInfo.dli_sname);
+   void* resolved = lookupRuntimeSymbol(RTLD_NEXT, lookup);
    const char* resolveError = ::dlerror();
    if(resolveError != 0 || resolved == 0 || resolved == address)
    {
@@ -335,7 +834,7 @@ AArch64PltResolution resolveCanonicalPltAddress(const void* address)
    }
 
    ::dlerror();
-   void* pinnedAddress = ::dlsym(moduleHandle, sourceInfo.dli_sname);
+   void* pinnedAddress = lookupRuntimeSymbol(moduleHandle, lookup);
    const char* pinError = ::dlerror();
    Dl_info pinnedInfo;
    if(pinError != 0 || pinnedAddress != resolved ||

--- a/src/AArch64PltResolver.cpp
+++ b/src/AArch64PltResolver.cpp
@@ -1,0 +1,406 @@
+/***
+   mockcpp is a C/C++ mock framework.
+   Copyright [2008] [Darwin Yuan <darwin.yuan@gmail.com>]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+***/
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
+#if defined(__aarch64__) && defined(__linux__)
+#  include <features.h>
+#endif
+
+#include "AArch64PltResolver.h"
+
+#if defined(__aarch64__) && defined(__linux__) && defined(__GLIBC__)
+
+#include <dlfcn.h>
+#include <elf.h>
+#include <link.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#endif
+
+MOCKCPP_NS_START
+
+#if defined(__aarch64__) && defined(__linux__) && defined(__GLIBC__)
+
+namespace
+{
+
+struct SegmentQuery
+{
+   SegmentQuery(const void* value, size_t rangeSize)
+      : address(reinterpret_cast<uintptr_t>(value))
+      , size(static_cast<uintptr_t>(rangeSize))
+      , found(false)
+   {
+   }
+
+   uintptr_t address;
+   uintptr_t size;
+   bool found;
+};
+
+int findReadableExecutableSegment(struct dl_phdr_info* info,
+                                  size_t,
+                                  void* data)
+{
+   SegmentQuery* query = static_cast<SegmentQuery*>(data);
+
+   for(ElfW(Half) i = 0; i < info->dlpi_phnum; ++i)
+   {
+      const ElfW(Phdr)& header = info->dlpi_phdr[i];
+      if(header.p_type != PT_LOAD ||
+         (header.p_flags & (PF_R | PF_X)) != (PF_R | PF_X))
+      {
+         continue;
+      }
+
+      const uintptr_t base = static_cast<uintptr_t>(info->dlpi_addr);
+      const uintptr_t offset = static_cast<uintptr_t>(header.p_vaddr);
+      if(base > UINTPTR_MAX - offset)
+      {
+         continue;
+      }
+
+      const uintptr_t start = base + offset;
+      const uintptr_t size = static_cast<uintptr_t>(header.p_memsz);
+      if(size < 4 || start > UINTPTR_MAX - size)
+      {
+         continue;
+      }
+
+      if(query->size == 0 ||
+         query->address > UINTPTR_MAX - query->size)
+      {
+         continue;
+      }
+
+      const uintptr_t end = start + size;
+      const uintptr_t queryEnd = query->address + query->size;
+      if(query->address >= start && queryEnd <= end)
+      {
+         query->found = true;
+         return 1;
+      }
+   }
+
+   return 0;
+}
+
+bool isReadableExecutableRange(const void* address, size_t size)
+{
+   SegmentQuery query(address, size);
+   ::dl_iterate_phdr(findReadableExecutableSegment, &query);
+   return query.found;
+}
+
+const void* dynamicAddress(const struct link_map* image, ElfW(Addr) value)
+{
+   // Canonical PLT resolution is deliberately restricted to an ET_EXEC
+   // image with l_addr == 0, so its dynamic pointers are already absolute.
+   if(image->l_addr != 0)
+   {
+      return 0;
+   }
+
+   return reinterpret_cast<const void*>(static_cast<uintptr_t>(value));
+}
+
+bool isMainExecutableImage(const Dl_info& info,
+                           const struct link_map* image)
+{
+   if(info.dli_fbase == 0 || image == 0 || image->l_addr != 0)
+   {
+      return false;
+   }
+
+   const Elf64_Ehdr* header =
+      static_cast<const Elf64_Ehdr*>(info.dli_fbase);
+   return header->e_ident[EI_MAG0] == ELFMAG0 &&
+          header->e_ident[EI_MAG1] == ELFMAG1 &&
+          header->e_ident[EI_MAG2] == ELFMAG2 &&
+          header->e_ident[EI_MAG3] == ELFMAG3 &&
+          header->e_ident[EI_CLASS] == ELFCLASS64 &&
+          header->e_ident[EI_DATA] == ELFDATA2LSB &&
+          header->e_type == ET_EXEC &&
+          header->e_machine == EM_AARCH64;
+}
+
+bool isUnversionedSymbol(const ElfW(Sym)* symbol,
+                         const struct link_map* image)
+{
+   if(image == 0 || image->l_ld == 0)
+   {
+      return false;
+   }
+
+   const ElfW(Sym)* symbolTable = 0;
+   const ElfW(Half)* versionTable = 0;
+
+   for(const ElfW(Dyn)* entry = image->l_ld;
+       entry->d_tag != DT_NULL;
+       ++entry)
+   {
+      if(entry->d_tag == DT_SYMTAB)
+      {
+         symbolTable = static_cast<const ElfW(Sym)*>(
+            dynamicAddress(image, entry->d_un.d_ptr));
+      }
+#ifdef DT_VERSYM
+      else if(entry->d_tag == DT_VERSYM)
+      {
+         versionTable = static_cast<const ElfW(Half)*>(
+            dynamicAddress(image, entry->d_un.d_ptr));
+      }
+#endif
+   }
+
+   if(symbolTable == 0)
+   {
+      return false;
+   }
+
+   const uintptr_t symbolAddress = reinterpret_cast<uintptr_t>(symbol);
+   const uintptr_t tableAddress = reinterpret_cast<uintptr_t>(symbolTable);
+   if(symbolAddress < tableAddress)
+   {
+      return false;
+   }
+
+   const uintptr_t byteOffset = symbolAddress - tableAddress;
+   if(byteOffset % sizeof(ElfW(Sym)) != 0)
+   {
+      return false;
+   }
+
+   if(versionTable == 0)
+   {
+      return true;
+   }
+
+   const size_t symbolIndex = byteOffset / sizeof(ElfW(Sym));
+   const ElfW(Half) version = versionTable[symbolIndex] & 0x7fffU;
+   return version <= 1;
+}
+
+bool beginsWithBti(const void* address)
+{
+   const unsigned char* instruction =
+      static_cast<const unsigned char*>(address);
+
+   // All four BTI variants have the little-endian byte pattern
+   // { 0x1f/0x5f/0x9f/0xdf, 0x24, 0x03, 0xd5 }.
+   return (instruction[0] & 0x3fU) == 0x1fU &&
+          instruction[1] == 0x24U &&
+          instruction[2] == 0x03U &&
+          instruction[3] == 0xd5U;
+}
+
+bool beginsWithPacReturnLandingPad(const void* address)
+{
+   const unsigned char* instruction =
+      static_cast<const unsigned char*>(address);
+
+   // PACIASP and PACIBSP can serve as call landing pads on a BTI guarded
+   // page.  They cannot be preserved before a jump to a normal C++ stub,
+   // because that would pass a signed LR to code which does not authenticate.
+   return (instruction[0] == 0x3fU || instruction[0] == 0x7fU) &&
+          instruction[1] == 0x23U &&
+          instruction[2] == 0x03U &&
+          instruction[3] == 0xd5U;
+}
+
+AArch64PltResolution canonicalPltFallback(const void* address)
+{
+   const unsigned char* patchAddress =
+      static_cast<const unsigned char*>(address);
+   if(isReadableExecutableRange(address, 4) && beginsWithBti(address))
+   {
+      // A function pointer can branch indirectly to a canonical PLT entry.
+      // Keep its BTI landing pad just as we do for the resolved SO target.
+      patchAddress += 4;
+   }
+
+   return AArch64PltResolution(patchAddress, 0);
+}
+
+#if defined(__GNUC__)
+__attribute__((noinline))
+#endif
+AArch64PltResolution resolveCanonicalPltAddress(const void* address)
+{
+   Dl_info sourceInfo;
+   void* symbolData = 0;
+   if(::dladdr1(address, &sourceInfo, &symbolData, RTLD_DL_SYMENT) == 0 ||
+      symbolData == 0 || sourceInfo.dli_saddr != address ||
+      sourceInfo.dli_sname == 0 || sourceInfo.dli_sname[0] == '\0')
+   {
+      return AArch64PltResolution(address, 0);
+   }
+
+   const ElfW(Sym)* symbol = static_cast<const ElfW(Sym)*>(symbolData);
+   const unsigned int symbolType = ELF64_ST_TYPE(symbol->st_info);
+   const unsigned int symbolBinding = ELF64_ST_BIND(symbol->st_info);
+   if(symbolType != STT_FUNC ||
+      (symbolBinding != STB_GLOBAL && symbolBinding != STB_WEAK) ||
+      symbol->st_shndx != SHN_UNDEF || symbol->st_value == 0)
+   {
+      return AArch64PltResolution(address, 0);
+   }
+
+   const AArch64PltResolution sourceFallback =
+      canonicalPltFallback(address);
+
+   Dl_info resolverInfo;
+   if(::dladdr(reinterpret_cast<const void*>(&resolveCanonicalPltAddress),
+               &resolverInfo) == 0 ||
+      sourceInfo.dli_fbase != resolverInfo.dli_fbase)
+   {
+      // RTLD_NEXT starts after the ELF object containing the caller.  The
+      // canonical PLT and this resolver must therefore be in the same image.
+      return sourceFallback;
+   }
+
+   Dl_info linkInfo;
+   void* linkData = 0;
+   if(::dladdr1(address, &linkInfo, &linkData, RTLD_DL_LINKMAP) == 0 ||
+      linkData == 0 || linkInfo.dli_fbase != sourceInfo.dli_fbase ||
+      !isMainExecutableImage(
+         sourceInfo, static_cast<const struct link_map*>(linkData)) ||
+      !isUnversionedSymbol(symbol,
+                           static_cast<const struct link_map*>(linkData)))
+   {
+      // dlsym() cannot express the exact relocation version without parsing
+      // the caller's version definition.  Do not guess for versioned imports.
+      return sourceFallback;
+   }
+
+   ::dlerror();
+   void* resolved = ::dlsym(RTLD_NEXT, sourceInfo.dli_sname);
+   const char* resolveError = ::dlerror();
+   if(resolveError != 0 || resolved == 0 || resolved == address)
+   {
+      return sourceFallback;
+   }
+
+   Dl_info targetInfo;
+   if(::dladdr(resolved, &targetInfo) == 0 ||
+      targetInfo.dli_fbase == sourceInfo.dli_fbase ||
+      targetInfo.dli_fname == 0 || targetInfo.dli_fname[0] == '\0' ||
+      !isReadableExecutableRange(resolved, 4))
+   {
+      return sourceFallback;
+   }
+
+   Dl_info targetSymbolInfo;
+   void* targetSymbolData = 0;
+   if(::dladdr1(resolved, &targetSymbolInfo, &targetSymbolData,
+                RTLD_DL_SYMENT) == 0 ||
+      targetSymbolData == 0 || targetSymbolInfo.dli_saddr != resolved ||
+      targetSymbolInfo.dli_fbase != targetInfo.dli_fbase)
+   {
+      return sourceFallback;
+   }
+
+   const ElfW(Sym)* targetSymbol =
+      static_cast<const ElfW(Sym)*>(targetSymbolData);
+   if(ELF64_ST_TYPE(targetSymbol->st_info) != STT_FUNC ||
+      targetSymbol->st_shndx == SHN_UNDEF || targetSymbol->st_size == 0 ||
+      beginsWithPacReturnLandingPad(resolved))
+   {
+      return sourceFallback;
+   }
+
+   void* moduleHandle =
+      ::dlopen(targetInfo.dli_fname, RTLD_NOLOAD | RTLD_LAZY);
+   if(moduleHandle == 0)
+   {
+      return sourceFallback;
+   }
+
+   ::dlerror();
+   void* pinnedAddress = ::dlsym(moduleHandle, sourceInfo.dli_sname);
+   const char* pinError = ::dlerror();
+   Dl_info pinnedInfo;
+   if(pinError != 0 || pinnedAddress != resolved ||
+      ::dladdr(pinnedAddress, &pinnedInfo) == 0 ||
+      pinnedInfo.dli_fbase != targetInfo.dli_fbase)
+   {
+      ::dlclose(moduleHandle);
+      return sourceFallback;
+   }
+
+   const unsigned char* patchAddress =
+      static_cast<const unsigned char*>(resolved);
+   size_t availablePatchSize = static_cast<size_t>(targetSymbol->st_size);
+   if(beginsWithBti(resolved))
+   {
+      // Preserve the indirect-call landing pad and install the jump after it.
+      patchAddress += 4;
+      if(availablePatchSize <= 4)
+      {
+         ::dlclose(moduleHandle);
+         return sourceFallback;
+      }
+      availablePatchSize -= 4;
+   }
+
+   return AArch64PltResolution(patchAddress,
+                               moduleHandle,
+                               availablePatchSize,
+                               sourceFallback.address);
+}
+
+}
+
+#endif
+
+AArch64PltResolution resolveAArch64PltAddress(const void* address)
+{
+#if defined(__aarch64__) && defined(__linux__) && defined(__GLIBC__)
+   return resolveCanonicalPltAddress(address);
+#else
+   return AArch64PltResolution(address, 0);
+#endif
+}
+
+bool isAArch64PatchRangeSafe(const void* address, size_t size)
+{
+#if defined(__aarch64__) && defined(__linux__) && defined(__GLIBC__)
+   return isReadableExecutableRange(address, size);
+#else
+   (void)address;
+   (void)size;
+   return true;
+#endif
+}
+
+void releaseAArch64PltModule(void* moduleHandle)
+{
+#if defined(__aarch64__) && defined(__linux__) && defined(__GLIBC__)
+   if(moduleHandle != 0)
+   {
+      ::dlclose(moduleHandle);
+   }
+#else
+   (void)moduleHandle;
+#endif
+}
+
+MOCKCPP_NS_END

--- a/src/AArch64PltResolver.h
+++ b/src/AArch64PltResolver.h
@@ -1,0 +1,52 @@
+/***
+   mockcpp is a C/C++ mock framework.
+   Copyright [2008] [Darwin Yuan <darwin.yuan@gmail.com>]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+***/
+#ifndef __MOCKCPP_AARCH64_PLT_RESOLVER_H__
+#define __MOCKCPP_AARCH64_PLT_RESOLVER_H__
+
+#include <stddef.h>
+
+#include <mockcpp/mockcpp.h>
+
+MOCKCPP_NS_START
+
+struct AArch64PltResolution
+{
+   AArch64PltResolution(const void* resolvedAddress,
+                        void* handle,
+                        size_t patchSize = 0,
+                        const void* safeFallbackAddress = 0)
+      : address(resolvedAddress)
+      , moduleHandle(handle)
+      , availablePatchSize(patchSize)
+      , fallbackAddress(safeFallbackAddress == 0
+                           ? resolvedAddress : safeFallbackAddress)
+   {
+   }
+
+   const void* address;
+   void* moduleHandle;
+   size_t availablePatchSize;
+   const void* fallbackAddress;
+};
+
+AArch64PltResolution resolveAArch64PltAddress(const void* address);
+bool isAArch64PatchRangeSafe(const void* address, size_t size);
+void releaseAArch64PltModule(void* moduleHandle);
+
+MOCKCPP_NS_END
+
+#endif

--- a/src/ApiHookKey.cpp
+++ b/src/ApiHookKey.cpp
@@ -24,9 +24,19 @@ MOCKCPP_NS_START
 ///////////////////////////////////////////////////////////
 ApiHookKey::ApiHookKey(const void* api, ApiHookHolder* holder)
    : apiAddress(api)
+   , hook(0)
    , hookHolder(holder)
 {
-   hook = new ApiHook(api, holder->getApiHook());
+   try
+   {
+      hook = new ApiHook(api, holder->getApiHook());
+   }
+   catch(...)
+   {
+      delete hookHolder;
+      hookHolder = 0;
+      throw;
+   }
 }
 
 ///////////////////////////////////////////////////////////

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,6 +179,7 @@ SET(MOCKCPP_SRCS
     GlobalMockObject.cpp
     JmpOnlyApiHook.cpp
     JmpCode.cpp
+    AArch64PltResolver.cpp
     ApiHook.cpp
 
 )
@@ -326,6 +327,10 @@ ENDFOREACH()
 LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/src ${CMAKE_BINARY_DIR}/tests/3rdparty/testngpp/src)
 
 ADD_LIBRARY(mockcpp STATIC ${MOCKCPP_SRCS})
+
+IF(CMAKE_DL_LIBS)
+   TARGET_LINK_LIBRARIES(mockcpp PUBLIC ${CMAKE_DL_LIBS})
+ENDIF()
 
 INCLUDE_DIRECTORIES(BEFORE ${MOCKCPP_SRC_ROOT}/include ${MOCKCPP_SRC_ROOT}/3rdparty)
 

--- a/src/JmpCode.cpp
+++ b/src/JmpCode.cpp
@@ -23,15 +23,21 @@
 
 MOCKCPP_NS_START
 
-#define JMP_CODE_SIZE sizeof(jmpCodeTemplate)
-
 struct JmpCodeImpl
 {
    ////////////////////////////////////////////////
    JmpCodeImpl(const void* from, const void* to)
+#if defined(__arm__) || defined(_M_ARM)
+      : m_codeSize(buildArmJmpCode(m_code, from, to))
+#else
+      : m_codeSize(sizeof(jmpCodeTemplate))
+#endif
+      , m_patchAddress(GET_JMP_CODE_PATCH_ADDRESS(from))
    {
-      ::memcpy(m_code, jmpCodeTemplate, JMP_CODE_SIZE);
+#if !defined(__arm__) && !defined(_M_ARM)
+      ::memcpy(m_code, jmpCodeTemplate, sizeof(jmpCodeTemplate));
       SET_JMP_CODE(m_code, from, to);
+#endif
    }
 
    ////////////////////////////////////////////////
@@ -43,12 +49,24 @@ struct JmpCodeImpl
    ////////////////////////////////////////////////
    size_t getCodeSize() const
    {
-      return JMP_CODE_SIZE;
+      return m_codeSize;
+   }
+
+   ////////////////////////////////////////////////
+   void* getPatchAddress() const
+   {
+      return m_patchAddress;
    }
 
    ////////////////////////////////////////////////
 
-   unsigned char m_code[JMP_CODE_SIZE];
+#if defined(__arm__) || defined(_M_ARM)
+   unsigned char m_code[MAX_JMP_CODE_SIZE];
+#else
+   unsigned char m_code[sizeof(jmpCodeTemplate)];
+#endif
+   size_t m_codeSize;
+   void* m_patchAddress;
 };
 
 ///////////////////////////////////////////////////
@@ -77,5 +95,11 @@ JmpCode::getCodeSize() const
    return This->getCodeSize();
 }
 
-MOCKCPP_NS_END
+///////////////////////////////////////////////////
+void*
+JmpCode::getPatchAddress() const
+{
+   return This->getPatchAddress();
+}
 
+MOCKCPP_NS_END

--- a/src/JmpCode.cpp
+++ b/src/JmpCode.cpp
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include <mockcpp/JmpCode.h>
+#include "AArch64PltResolver.h"
 #include "JmpCodeArch.h"
 
 MOCKCPP_NS_START
@@ -27,20 +28,38 @@ struct JmpCodeImpl
 {
    ////////////////////////////////////////////////
    JmpCodeImpl(const void* from, const void* to)
-#if defined(__aarch64__) || defined(_M_ARM64)
-      : m_codeSize(buildAArch64JmpCode(m_code, from, to))
-#elif defined(__arm__) || defined(_M_ARM)
-      : m_codeSize(buildArmJmpCode(m_code, from, to))
-#else
-      : m_codeSize(sizeof(jmpCodeTemplate))
-#endif
+      : m_codeSize(0)
       , m_patchAddress(GET_JMP_CODE_PATCH_ADDRESS(from))
+      , m_patchModuleHandle(0)
    {
-#if !defined(__aarch64__) && !defined(_M_ARM64) && \
-    !defined(__arm__) && !defined(_M_ARM)
+#if defined(__aarch64__) || defined(_M_ARM64)
+      const AArch64PltResolution resolved =
+         resolveAArch64PltAddress(from);
+      m_patchAddress = const_cast<void*>(resolved.address);
+      m_patchModuleHandle = resolved.moduleHandle;
+      m_codeSize = buildAArch64JmpCode(m_code, m_patchAddress, to);
+      if(m_patchModuleHandle != 0 &&
+         (m_codeSize > resolved.availablePatchSize ||
+          !isAArch64PatchRangeSafe(m_patchAddress, m_codeSize)))
+      {
+         releaseAArch64PltModule(m_patchModuleHandle);
+         m_patchModuleHandle = 0;
+         m_patchAddress = const_cast<void*>(resolved.fallbackAddress);
+         m_codeSize = buildAArch64JmpCode(m_code, m_patchAddress, to);
+      }
+#elif defined(__arm__) || defined(_M_ARM)
+      m_codeSize = buildArmJmpCode(m_code, from, to);
+#else
+      m_codeSize = sizeof(jmpCodeTemplate);
       ::memcpy(m_code, jmpCodeTemplate, sizeof(jmpCodeTemplate));
       SET_JMP_CODE(m_code, from, to);
 #endif
+   }
+
+   ////////////////////////////////////////////////
+   ~JmpCodeImpl()
+   {
+      releaseAArch64PltModule(m_patchModuleHandle);
    }
 
    ////////////////////////////////////////////////
@@ -71,6 +90,7 @@ struct JmpCodeImpl
 #endif
    size_t m_codeSize;
    void* m_patchAddress;
+   void* m_patchModuleHandle;
 };
 
 ///////////////////////////////////////////////////

--- a/src/JmpCode.cpp
+++ b/src/JmpCode.cpp
@@ -27,14 +27,17 @@ struct JmpCodeImpl
 {
    ////////////////////////////////////////////////
    JmpCodeImpl(const void* from, const void* to)
-#if defined(__arm__) || defined(_M_ARM)
+#if defined(__aarch64__) || defined(_M_ARM64)
+      : m_codeSize(buildAArch64JmpCode(m_code, from, to))
+#elif defined(__arm__) || defined(_M_ARM)
       : m_codeSize(buildArmJmpCode(m_code, from, to))
 #else
       : m_codeSize(sizeof(jmpCodeTemplate))
 #endif
       , m_patchAddress(GET_JMP_CODE_PATCH_ADDRESS(from))
    {
-#if !defined(__arm__) && !defined(_M_ARM)
+#if !defined(__aarch64__) && !defined(_M_ARM64) && \
+    !defined(__arm__) && !defined(_M_ARM)
       ::memcpy(m_code, jmpCodeTemplate, sizeof(jmpCodeTemplate));
       SET_JMP_CODE(m_code, from, to);
 #endif
@@ -60,7 +63,8 @@ struct JmpCodeImpl
 
    ////////////////////////////////////////////////
 
-#if defined(__arm__) || defined(_M_ARM)
+#if defined(__aarch64__) || defined(_M_ARM64) || \
+    defined(__arm__) || defined(_M_ARM)
    unsigned char m_code[MAX_JMP_CODE_SIZE];
 #else
    unsigned char m_code[sizeof(jmpCodeTemplate)];

--- a/src/JmpCode.cpp
+++ b/src/JmpCode.cpp
@@ -18,11 +18,148 @@
 #include <inttypes.h>
 #include <string.h>
 
+#if defined(__aarch64__) && defined(__linux__)
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
 #include <mockcpp/JmpCode.h>
 #include "AArch64PltResolver.h"
 #include "JmpCodeArch.h"
 
 MOCKCPP_NS_START
+
+#if defined(__aarch64__) && defined(__linux__)
+
+namespace
+{
+
+void* mapAArch64TrampolinePage(const void* from, size_t pageSize)
+{
+   const uintptr_t fromAddress = reinterpret_cast<uintptr_t>(from);
+   const uintptr_t sourcePage = fromAddress - fromAddress % pageSize;
+   const uintptr_t branchRange = static_cast<uintptr_t>(1) << 27;
+
+   // A non-fixed mmap hint never replaces an existing mapping.  Probe the
+   // branch window at 64 KiB intervals so the kernel can choose a nearby gap
+   // without relying on MAP_FIXED_NOREPLACE availability.
+   uintptr_t step = static_cast<uintptr_t>(64) << 10;
+   if(step < pageSize)
+   {
+      step = pageSize;
+   }
+   step -= step % pageSize;
+
+   const size_t attempts = static_cast<size_t>(branchRange / step);
+   for(size_t index = 0; index <= attempts; ++index)
+   {
+      const uintptr_t distance = static_cast<uintptr_t>(index) * step;
+      for(unsigned int direction = 0; direction < 2; ++direction)
+      {
+         if(index == 0 && direction != 0)
+         {
+            continue;
+         }
+
+         uintptr_t hintAddress = 0;
+         if(direction == 0)
+         {
+            if(sourcePage > UINTPTR_MAX - distance)
+            {
+               continue;
+            }
+            hintAddress = sourcePage + distance;
+         }
+         else
+         {
+            if(sourcePage < distance)
+            {
+               continue;
+            }
+            hintAddress = sourcePage - distance;
+         }
+
+         void* page = ::mmap(reinterpret_cast<void*>(hintAddress),
+                             pageSize,
+                             PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS,
+                             -1,
+                             0);
+         if(page == MAP_FAILED)
+         {
+            continue;
+         }
+         if(page == 0)
+         {
+            ::munmap(page, pageSize);
+            continue;
+         }
+
+         unsigned char branch[MAX_JMP_CODE_SIZE];
+         if(buildAArch64JmpCode(branch, from, page) == sizeof(uint32_t))
+         {
+            return page;
+         }
+
+         ::munmap(page, pageSize);
+      }
+   }
+
+   return 0;
+}
+
+void* createAArch64NearTrampoline(const void* from,
+                                  const void* to,
+                                  size_t* mappingSize)
+{
+   const long configuredPageSize = ::sysconf(_SC_PAGESIZE);
+   if(configuredPageSize <= 0)
+   {
+      return 0;
+   }
+
+   const size_t pageSize = static_cast<size_t>(configuredPageSize);
+   if(pageSize < MAX_JMP_CODE_SIZE)
+   {
+      return 0;
+   }
+
+   void* page = mapAArch64TrampolinePage(from, pageSize);
+   if(page == 0)
+   {
+      return 0;
+   }
+
+   unsigned char trampoline[MAX_JMP_CODE_SIZE];
+   const size_t trampolineSize = buildAArch64JmpCode(trampoline, page, to);
+   ::memcpy(page, trampoline, trampolineSize);
+
+#if defined(__GNUC__) || defined(__clang__)
+   __builtin___clear_cache(static_cast<char*>(page),
+                           static_cast<char*>(page) + trampolineSize);
+#endif
+
+   if(::mprotect(page, pageSize, PROT_READ | PROT_EXEC) != 0)
+   {
+      ::munmap(page, pageSize);
+      return 0;
+   }
+
+   *mappingSize = pageSize;
+   return page;
+}
+
+void releaseAArch64NearTrampoline(void* address, size_t mappingSize)
+{
+   if(address != 0)
+   {
+      ::munmap(address, mappingSize);
+   }
+}
+
+}
+
+#endif
 
 struct JmpCodeImpl
 {
@@ -31,6 +168,9 @@ struct JmpCodeImpl
       : m_codeSize(0)
       , m_patchAddress(GET_JMP_CODE_PATCH_ADDRESS(from))
       , m_patchModuleHandle(0)
+      , m_trampolineAddress(0)
+      , m_trampolineSize(0)
+      , m_hookInstalled(false)
    {
 #if defined(__aarch64__) || defined(_M_ARM64)
       const AArch64PltResolution resolved =
@@ -42,10 +182,42 @@ struct JmpCodeImpl
          (m_codeSize > resolved.availablePatchSize ||
           !isAArch64PatchRangeSafe(m_patchAddress, m_codeSize)))
       {
-         releaseAArch64PltModule(m_patchModuleHandle);
-         m_patchModuleHandle = 0;
-         m_patchAddress = const_cast<void*>(resolved.fallbackAddress);
-         m_codeSize = buildAArch64JmpCode(m_code, m_patchAddress, to);
+#if defined(__linux__)
+         if(resolved.availablePatchSize >= sizeof(uint32_t) &&
+            isAArch64PatchRangeSafe(m_patchAddress, sizeof(uint32_t)))
+         {
+            m_trampolineAddress = createAArch64NearTrampoline(
+               m_patchAddress, to, &m_trampolineSize);
+            if(m_trampolineAddress != 0)
+            {
+               m_codeSize = buildAArch64JmpCode(
+                  m_code, m_patchAddress, m_trampolineAddress);
+            }
+         }
+#endif
+
+         if(m_trampolineAddress != 0 &&
+            m_codeSize == sizeof(uint32_t) &&
+            m_codeSize <= resolved.availablePatchSize &&
+            isAArch64PatchRangeSafe(m_patchAddress, m_codeSize))
+         {
+            // Keep the pinned module and trampoline until the hook has first
+            // been restored.  Destruction may otherwise unmap executable code
+            // while the target still branches to it.
+         }
+         else
+         {
+#if defined(__aarch64__) && defined(__linux__)
+            releaseAArch64NearTrampoline(
+               m_trampolineAddress, m_trampolineSize);
+            m_trampolineAddress = 0;
+            m_trampolineSize = 0;
+#endif
+            releaseAArch64PltModule(m_patchModuleHandle);
+            m_patchModuleHandle = 0;
+            m_patchAddress = const_cast<void*>(resolved.fallbackAddress);
+            m_codeSize = buildAArch64JmpCode(m_code, m_patchAddress, to);
+         }
       }
 #elif defined(__arm__) || defined(_M_ARM)
       m_codeSize = buildArmJmpCode(m_code, from, to);
@@ -59,7 +231,38 @@ struct JmpCodeImpl
    ////////////////////////////////////////////////
    ~JmpCodeImpl()
    {
-      releaseAArch64PltModule(m_patchModuleHandle);
+#if defined(__aarch64__) && defined(__linux__)
+      if(!m_hookInstalled)
+      {
+         releaseAArch64NearTrampoline(
+            m_trampolineAddress, m_trampolineSize);
+      }
+#endif
+      if(!m_hookInstalled)
+      {
+         releaseAArch64PltModule(m_patchModuleHandle);
+      }
+   }
+
+   void markInstalled()
+   {
+      m_hookInstalled = true;
+   }
+
+   void markRestored()
+   {
+      if(!m_hookInstalled)
+      {
+         return;
+      }
+
+      m_hookInstalled = false;
+      // A caller may already have fetched the old branch when reset restores
+      // the target.  Published trampoline code must therefore stay mapped for
+      // the process lifetime; reclaiming it requires a real quiescence/epoch
+      // protocol which mockcpp does not currently have.
+      m_trampolineAddress = 0;
+      m_trampolineSize = 0;
    }
 
    ////////////////////////////////////////////////
@@ -91,6 +294,9 @@ struct JmpCodeImpl
    size_t m_codeSize;
    void* m_patchAddress;
    void* m_patchModuleHandle;
+   void* m_trampolineAddress;
+   size_t m_trampolineSize;
+   bool m_hookInstalled;
 };
 
 ///////////////////////////////////////////////////
@@ -124,6 +330,18 @@ void*
 JmpCode::getPatchAddress() const
 {
    return This->getPatchAddress();
+}
+
+void
+JmpCode::markInstalled()
+{
+   This->markInstalled();
+}
+
+void
+JmpCode::markRestored()
+{
+   This->markRestored();
 }
 
 MOCKCPP_NS_END

--- a/src/JmpCodeAArch64.h
+++ b/src/JmpCodeAArch64.h
@@ -17,16 +17,59 @@
 #ifndef __MOCKCPP_JMP_CODE_AARCH64_H__
 #define __MOCKCPP_JMP_CODE_AARCH64_H__
 
-// ldr x16, #8; br x16; .quad target
+// Far jump: ldr x16, #8; br x16; .quad target
 // x16 is an intra-procedure-call scratch register under AAPCS64.
-const unsigned char jmpCodeTemplate[] =
+const unsigned char aarch64AbsoluteJmpCodeTemplate[] =
    { 0x50, 0x00, 0x00, 0x58, 0x00, 0x02, 0x1F, 0xD6,
      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-#define SET_JMP_CODE(base, from, to) do { \
-       uintptr_t targetAddress = (uintptr_t)(to); \
-       ::memcpy((base) + 8, &targetAddress, sizeof(targetAddress)); \
-   } while(0)
+const size_t MAX_JMP_CODE_SIZE = sizeof(aarch64AbsoluteJmpCodeTemplate);
+
+inline size_t buildAArch64JmpCode(unsigned char* code,
+                                  const void* from,
+                                  const void* to)
+{
+   const uintptr_t fromAddress = reinterpret_cast<uintptr_t>(from);
+   const uintptr_t targetAddress = reinterpret_cast<uintptr_t>(to);
+
+   // B uses a signed imm26 scaled by four: [-128 MiB, 128 MiB).
+   // Prefer it because a valid AArch64 function may be only 4 or 8 bytes.
+   uintptr_t distance = 0;
+   uint32_t immediate = 0;
+   bool canUseDirectBranch = false;
+
+   if(targetAddress >= fromAddress)
+   {
+      distance = targetAddress - fromAddress;
+      canUseDirectBranch = (distance & 3U) == 0 &&
+                           distance < (static_cast<uintptr_t>(1) << 27);
+      immediate = static_cast<uint32_t>(distance >> 2);
+   }
+   else
+   {
+      distance = fromAddress - targetAddress;
+      canUseDirectBranch = (distance & 3U) == 0 &&
+                           distance <= (static_cast<uintptr_t>(1) << 27);
+      immediate = 0U - static_cast<uint32_t>(distance >> 2);
+   }
+
+   if(canUseDirectBranch)
+   {
+      const uint32_t branch = 0x14000000U | (immediate & 0x03FFFFFFU);
+      // A64 instructions are always fetched little-endian, including on
+      // big-endian AArch64 systems.
+      code[0] = static_cast<unsigned char>(branch);
+      code[1] = static_cast<unsigned char>(branch >> 8);
+      code[2] = static_cast<unsigned char>(branch >> 16);
+      code[3] = static_cast<unsigned char>(branch >> 24);
+      return sizeof(branch);
+   }
+
+   ::memcpy(code, aarch64AbsoluteJmpCodeTemplate,
+            sizeof(aarch64AbsoluteJmpCodeTemplate));
+   ::memcpy(code + 8, &targetAddress, sizeof(targetAddress));
+   return sizeof(aarch64AbsoluteJmpCodeTemplate);
+}
 
 #define GET_JMP_CODE_PATCH_ADDRESS(from) (const_cast<void*>(from))
 

--- a/src/JmpCodeAArch64.h
+++ b/src/JmpCodeAArch64.h
@@ -14,21 +14,20 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ***/
-#ifndef __MOCKCPP_JMP_CODE_ARCH_H__
-#define __MOCKCPP_JMP_CODE_ARCH_H__
+#ifndef __MOCKCPP_JMP_CODE_AARCH64_H__
+#define __MOCKCPP_JMP_CODE_AARCH64_H__
 
-#include <mockcpp/mockcpp.h>
+// ldr x16, #8; br x16; .quad target
+// x16 is an intra-procedure-call scratch register under AAPCS64.
+const unsigned char jmpCodeTemplate[] =
+   { 0x50, 0x00, 0x00, 0x58, 0x00, 0x02, 0x1F, 0xD6,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-#if defined(__aarch64__) || defined(_M_ARM64)
-# include "JmpCodeAArch64.h"
-#elif defined(__arm__) || defined(_M_ARM)
-# include "JmpCodeARM.h"
-#elif BUILD_FOR_X64
-# include "JmpCodeX64.h"
-#elif BUILD_FOR_X86
-# include "JmpCodeX86.h"
-#else
-# error "Unsupported architecture for mockcpp API hook"
-#endif
+#define SET_JMP_CODE(base, from, to) do { \
+       uintptr_t targetAddress = (uintptr_t)(to); \
+       ::memcpy((base) + 8, &targetAddress, sizeof(targetAddress)); \
+   } while(0)
+
+#define GET_JMP_CODE_PATCH_ADDRESS(from) (const_cast<void*>(from))
 
 #endif

--- a/src/JmpCodeARM.h
+++ b/src/JmpCodeARM.h
@@ -1,0 +1,68 @@
+/***
+   mockcpp is a C/C++ mock framework.
+   Copyright [2008] [Darwin Yuan <darwin.yuan@gmail.com>]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+***/
+#ifndef __MOCKCPP_JMP_CODE_ARM_H__
+#define __MOCKCPP_JMP_CODE_ARM_H__
+
+// ARM/A32: ldr pc, [pc, #-4]; .word target
+const unsigned char armJmpCodeTemplate[] =
+   { 0x04, 0xF0, 0x1F, 0xE5, 0x00, 0x00, 0x00, 0x00 };
+
+// Thumb-2, word-aligned entry: ldr.w pc, [pc]; .word target
+const unsigned char thumbAlignedJmpCodeTemplate[] =
+   { 0xDF, 0xF8, 0x00, 0xF0, 0x00, 0x00, 0x00, 0x00 };
+
+// Thumb-2, halfword-aligned entry: ldr.w pc, [pc, #4]; nop; .word target
+const unsigned char thumbHalfwordJmpCodeTemplate[] =
+   { 0xDF, 0xF8, 0x04, 0xF0, 0x00, 0xBF,
+     0x00, 0x00, 0x00, 0x00 };
+
+const size_t MAX_JMP_CODE_SIZE = sizeof(thumbHalfwordJmpCodeTemplate);
+
+inline size_t buildArmJmpCode(unsigned char* code, const void* from, const void* to)
+{
+   const uintptr_t fromAddress = (uintptr_t)from;
+   const uintptr_t targetAddress = (uintptr_t)to;
+
+   if ((fromAddress & 1U) == 0)
+   {
+      ::memcpy(code, armJmpCodeTemplate, sizeof(armJmpCodeTemplate));
+      const uint32_t target = (uint32_t)targetAddress;
+      ::memcpy(code + 4, &target, sizeof(target));
+      return sizeof(armJmpCodeTemplate);
+   }
+
+   const uintptr_t patchAddress = fromAddress & ~(uintptr_t)1U;
+   if ((patchAddress & 3U) == 0)
+   {
+      ::memcpy(code, thumbAlignedJmpCodeTemplate,
+               sizeof(thumbAlignedJmpCodeTemplate));
+      const uint32_t target = (uint32_t)targetAddress;
+      ::memcpy(code + 4, &target, sizeof(target));
+      return sizeof(thumbAlignedJmpCodeTemplate);
+   }
+
+   ::memcpy(code, thumbHalfwordJmpCodeTemplate,
+            sizeof(thumbHalfwordJmpCodeTemplate));
+   const uint32_t target = (uint32_t)targetAddress;
+   ::memcpy(code + 6, &target, sizeof(target));
+   return sizeof(thumbHalfwordJmpCodeTemplate);
+}
+
+#define GET_JMP_CODE_PATCH_ADDRESS(from) \
+   ((void*)((uintptr_t)(from) & ~(uintptr_t)1U))
+
+#endif

--- a/src/JmpCodeX64.h
+++ b/src/JmpCodeX64.h
@@ -24,8 +24,10 @@ const unsigned char jmpCodeTemplate[]  =
    { 0xFF, 0x25, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
 #define SET_JMP_CODE(base, from, to) do { \
-       *(uintptr_t *)(base + 6) = (uintptr_t)to; \
+       uintptr_t targetAddress = (uintptr_t)(to); \
+       ::memcpy((base) + 6, &targetAddress, sizeof(targetAddress)); \
    } while(0)
 
-#endif
+#define GET_JMP_CODE_PATCH_ADDRESS(from) (const_cast<void*>(from))
 
+#endif

--- a/src/JmpCodeX86.h
+++ b/src/JmpCodeX86.h
@@ -19,9 +19,11 @@
 
 const unsigned char jmpCodeTemplate[]  = { 0xE9, 0x00, 0x00, 0x00, 0x00 };
 #define SET_JMP_CODE(base, from, to) do { \
-        *(unsigned long*)(base + 1) = \
-            (unsigned long long)to - (unsigned long long)from - sizeof(jmpCodeTemplate); \
+        uint32_t relativeAddress = (uint32_t)( \
+            (uintptr_t)(to) - (uintptr_t)(from) - sizeof(jmpCodeTemplate)); \
+        ::memcpy((base) + 1, &relativeAddress, sizeof(relativeAddress)); \
    } while(0)
 
-#endif
+#define GET_JMP_CODE_PATCH_ADDRESS(from) (const_cast<void*>(from))
 
+#endif

--- a/src/JmpOnlyApiHook.cpp
+++ b/src/JmpOnlyApiHook.cpp
@@ -60,6 +60,7 @@ struct JmpOnlyApiHookImpl
       // after WriteProcessMemory has already installed the jump.  Preserve the
       // historical ownership behavior until its result can express that state.
       changeCode(m_jmpCode.getCodeData());
+      m_jmpCode.markInstalled();
 #else
       if(!changeCode(m_jmpCode.getCodeData()))
       {
@@ -67,6 +68,10 @@ struct JmpOnlyApiHookImpl
          m_originalData = 0;
          MOCKCPP_REPORT_FAILURE(
             "mockcpp failed to install API hook: unable to modify target code");
+      }
+      else
+      {
+         m_jmpCode.markInstalled();
       }
 #endif
    }
@@ -79,7 +84,13 @@ struct JmpOnlyApiHookImpl
          return;
       }
 
-      changeCode(m_originalData);
+      if(!changeCode(m_originalData))
+      {
+         // Keep all executable support storage alive if restoration failed.
+         // The process is still patched and must never jump to unmapped code.
+         return;
+      }
+      m_jmpCode.markRestored();
       delete [] m_originalData;
       m_originalData = 0;
    }

--- a/src/JmpOnlyApiHook.cpp
+++ b/src/JmpOnlyApiHook.cpp
@@ -32,7 +32,7 @@ struct JmpOnlyApiHookImpl
               , const void* stub)
 		: m_jmpCode(api, stub)
         , m_originalData(0)
-        , m_api(api)
+        , m_api(m_jmpCode.getPatchAddress())
    {
       startHook();
    }
@@ -67,13 +67,13 @@ struct JmpOnlyApiHookImpl
    /////////////////////////////////////////////////////
    void changeCode(const void* data)
    {
-      CodeModifier::modify(const_cast<void*>(m_api), data, m_jmpCode.getCodeSize());
+      CodeModifier::modify(m_api, data, m_jmpCode.getCodeSize());
    }
 
    /////////////////////////////////////////////////////
    JmpCode m_jmpCode;
    char* m_originalData;
-   const void* m_api;
+   void* m_api;
 };
 
 /////////////////////////////////////////////////////////////////
@@ -93,4 +93,3 @@ JmpOnlyApiHook::~JmpOnlyApiHook()
 /////////////////////////////////////////////////////////////////
 
 MOCKCPP_NS_END
-

--- a/src/JmpOnlyApiHook.cpp
+++ b/src/JmpOnlyApiHook.cpp
@@ -20,6 +20,7 @@
 #include "JmpOnlyApiHook.h"
 #include <mockcpp/JmpCode.h>
 #include <mockcpp/CodeModifier.h>
+#include <mockcpp/ReportFailure.h>
 
 MOCKCPP_NS_START
 
@@ -54,20 +55,39 @@ struct JmpOnlyApiHookImpl
    void startHook()
    {
       saveOriginalData();
+#if defined(_WIN32) || defined(_WIN64)
+      // WinCodeModifier can report a cache-flush or protection-restore failure
+      // after WriteProcessMemory has already installed the jump.  Preserve the
+      // historical ownership behavior until its result can express that state.
       changeCode(m_jmpCode.getCodeData());
+#else
+      if(!changeCode(m_jmpCode.getCodeData()))
+      {
+         delete [] m_originalData;
+         m_originalData = 0;
+         MOCKCPP_REPORT_FAILURE(
+            "mockcpp failed to install API hook: unable to modify target code");
+      }
+#endif
    }
 
    /////////////////////////////////////////////////////
    void stopHook()
    {
+      if(m_originalData == 0)
+      {
+         return;
+      }
+
       changeCode(m_originalData);
       delete [] m_originalData;
+      m_originalData = 0;
    }
 
    /////////////////////////////////////////////////////
-   void changeCode(const void* data)
+   bool changeCode(const void* data)
    {
-      CodeModifier::modify(m_api, data, m_jmpCode.getCodeSize());
+      return CodeModifier::modify(m_api, data, m_jmpCode.getCodeSize());
    }
 
    /////////////////////////////////////////////////////

--- a/src/UnixCodeModifier.cpp
+++ b/src/UnixCodeModifier.cpp
@@ -38,6 +38,11 @@ bool CodeModifier::modify(void *dest, const void *src, size_t size)
 
     ::memcpy(dest, src, size);
 
+#if defined(__GNUC__) || defined(__clang__)
+    __builtin___clear_cache(static_cast<char*>(dest),
+                            static_cast<char*>(dest) + size);
+#endif
+
 
 #if 0
 	#if BUILD_FOR_X86

--- a/src/UnixCodeModifier.cpp
+++ b/src/UnixCodeModifier.cpp
@@ -22,18 +22,29 @@
 
 #include <mockcpp/CodeModifier.h>
 
-//////////////////////////////////////////////////////////////////
-#define ALIGN_TO_PAGE_BOUNDARY(addr, page_size) (void*) (((uintptr_t)addr) & (~(page_size - 1)))
-//////////////////////////////////////////////////////////////////
-
 MOCKCPP_NS_START
 
 bool CodeModifier::modify(void *dest, const void *src, size_t size)
 {
-    int page_size = getpagesize();
-    if(::mprotect(ALIGN_TO_PAGE_BOUNDARY(dest, page_size), page_size * 2, PROT_EXEC | PROT_WRITE | PROT_READ ) != 0)
-    {  
-       return false; 
+    if(size == 0)
+    {
+       return true;
+    }
+
+    const size_t page_size = static_cast<size_t>(getpagesize());
+    const uintptr_t page_mask = static_cast<uintptr_t>(page_size - 1);
+    const uintptr_t first_page = reinterpret_cast<uintptr_t>(dest) & ~page_mask;
+    const uintptr_t last_page =
+       (reinterpret_cast<uintptr_t>(dest) + size - 1) & ~page_mask;
+    // mprotect fails if any page in the requested range is unmapped.
+    // Protect only the pages that the patch actually touches.
+    const size_t protected_size =
+       static_cast<size_t>(last_page - first_page) + page_size;
+
+    if(::mprotect(reinterpret_cast<void*>(first_page), protected_size,
+                  PROT_EXEC | PROT_WRITE | PROT_READ) != 0)
+    {
+       return false;
     }
 
     ::memcpy(dest, src, size);

--- a/src/WinCodeModifier.cpp
+++ b/src/WinCodeModifier.cpp
@@ -30,6 +30,8 @@ bool CodeModifier::modify(void *dest, const void *src, size_t size)
 	bRet = ::VirtualProtect(dest, size, dwReadWrite, &dwOldProtect);
 	bRet =  bRet && 
 		::WriteProcessMemory( ::GetCurrentProcess(), dest, src,  size, NULL );
+	bRet = bRet &&
+		::FlushInstructionCache(::GetCurrentProcess(), dest, size);
 	bRet =  bRet && 
 		::VirtualProtect(dest, size, dwOldProtect, &dwReadWrite);
 	return (bRet == TRUE);
@@ -37,4 +39,3 @@ bool CodeModifier::modify(void *dest, const void *src, size_t size)
 
 
 MOCKCPP_NS_END
-

--- a/tests/ut/CMakeLists.txt
+++ b/tests/ut/CMakeLists.txt
@@ -41,6 +41,7 @@ SET(UT_CASES
   TestStringConstraint.h
   TestStubContainter.h
   TestCheck.h
+  TestCodeModifier.h
   TestApiHook.h
   TestStaticMethodMocker.h
   #TestNonvirtualMethodMocker.h

--- a/tests/ut/CMakeLists.txt
+++ b/tests/ut/CMakeLists.txt
@@ -135,7 +135,8 @@ FOREACH(CASE ${UT_CASES})
 
   TARGET_LINK_LIBRARIES(${CASE_MODULE}
     testngpp-static
-    mockcpp)
+    mockcpp
+    ${CMAKE_DL_LIBS})
 
   ADD_CUSTOM_COMMAND(
     OUTPUT ${CASE_SRC}
@@ -145,3 +146,23 @@ FOREACH(CASE ${UT_CASES})
 
   ADD_DEPENDENCIES(${CASE_MODULE} ${CASE_NAME})
 ENDFOREACH()
+
+IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  INCLUDE(CheckCXXSourceCompiles)
+  CHECK_CXX_SOURCE_COMPILES("
+    #include <features.h>
+    #if !defined(__aarch64__) || !defined(__linux__) || !defined(__GLIBC__) || defined(__AARCH64EB__)
+    #error unsupported platform
+    #endif
+    int main() { return 0; }
+    " MOCKCPP_HAS_AARCH64_GLIBC)
+
+  IF(MOCKCPP_HAS_AARCH64_GLIBC)
+    ADD_SUBDIRECTORY(cross_so)
+    ADD_DEPENDENCIES(mockcpp-ut-TestCodeModifier
+      mockcpp-aarch64-cross-so-lazy
+      mockcpp-aarch64-cross-so-now)
+    TARGET_COMPILE_DEFINITIONS(mockcpp-ut-TestCodeModifier PRIVATE
+      MOCKCPP_AARCH64_CROSS_SO_TESTS=1)
+  ENDIF()
+ENDIF()

--- a/tests/ut/TestApiHook.h
+++ b/tests/ut/TestApiHook.h
@@ -68,6 +68,14 @@ FIXTURE(ApiHook)
 		ASSERT_EQ(ret, func(a, b));
 	}
 
+	TEST(can restore C function after reset)
+	{
+		ASSERT_EQ(ret, func(a, b));
+		GlobalMockObject::verify();
+		GlobalMockObject::reset();
+		ASSERT_EQ(0, func(a, b));
+	}
+
 	TEST(should throw some exception when calling the mocked function with wrong parameter)
 	{
 	    #ifdef _MSC_VER

--- a/tests/ut/TestCodeModifier.h
+++ b/tests/ut/TestCodeModifier.h
@@ -17,6 +17,7 @@
 
 #include <testngpp/testngpp.hpp>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <mockcpp/JmpCode.h>
 
@@ -127,5 +128,22 @@ FIXTURE(AArch64JmpCode)
       ASSERT_EQ(static_cast<size_t>(16), jmpCode.getCodeSize());
    }
 };
+
+#if defined(MOCKCPP_AARCH64_CROSS_SO_TESTS)
+
+FIXTURE(AArch64CrossSoHook)
+{
+   TEST(resolves a lazy canonical PLT entry to the function in its shared object)
+   {
+      ASSERT_EQ(0, ::system("./cross_so/mockcpp-aarch64-cross-so-lazy"));
+   }
+
+   TEST(resolves an eagerly bound canonical PLT entry to the function in its shared object)
+   {
+      ASSERT_EQ(0, ::system("./cross_so/mockcpp-aarch64-cross-so-now"));
+   }
+};
+
+#endif
 
 #endif

--- a/tests/ut/TestCodeModifier.h
+++ b/tests/ut/TestCodeModifier.h
@@ -1,0 +1,131 @@
+/***
+   mockcpp is a C/C++ mock framework.
+   Copyright [2008] [Darwin Yuan <darwin.yuan@gmail.com>]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+***/
+
+#include <testngpp/testngpp.hpp>
+#include <stdint.h>
+
+#include <mockcpp/JmpCode.h>
+
+USING_MOCKCPP_NS
+USING_TESTNGPP_NS
+
+#if defined(__linux__)
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <mockcpp/CodeModifier.h>
+
+FIXTURE(CodeModifierPageRange)
+{
+   TEST(does not require an untouched following page to be mapped)
+   {
+      const size_t pageSize = static_cast<size_t>(getpagesize());
+      unsigned char* pages = static_cast<unsigned char*>(
+         ::mmap(0, pageSize * 2, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+
+      ASSERT_TRUE(pages != static_cast<unsigned char*>(MAP_FAILED));
+      pages[0] = 0;
+
+      ASSERT_EQ(0, ::munmap(pages + pageSize, pageSize));
+      ASSERT_EQ(0, ::mprotect(pages, pageSize, PROT_READ | PROT_EXEC));
+
+      const unsigned char replacement = 0x5A;
+      ASSERT_TRUE(CodeModifier::modify(
+         pages, &replacement, sizeof(replacement)));
+      ASSERT_EQ(replacement, pages[0]);
+
+      ASSERT_EQ(0, ::munmap(pages, pageSize));
+   }
+};
+
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+FIXTURE(AArch64JmpCode)
+{
+   TEST(uses one branch instruction for a nearby target)
+   {
+      const void* from = reinterpret_cast<const void*>(
+         static_cast<uintptr_t>(0x100000));
+      const void* to = reinterpret_cast<const void*>(
+         static_cast<uintptr_t>(0x100100));
+      JmpCode jmpCode(from, to);
+
+      ASSERT_EQ(sizeof(uint32_t), jmpCode.getCodeSize());
+
+      const unsigned char* branch = static_cast<const unsigned char*>(
+         jmpCode.getCodeData());
+      ASSERT_EQ(static_cast<unsigned char>(0x40), branch[0]);
+      ASSERT_EQ(static_cast<unsigned char>(0x00), branch[1]);
+      ASSERT_EQ(static_cast<unsigned char>(0x00), branch[2]);
+      ASSERT_EQ(static_cast<unsigned char>(0x14), branch[3]);
+   }
+
+   TEST(encodes a nearby backward branch)
+   {
+      const void* from = reinterpret_cast<const void*>(
+         static_cast<uintptr_t>(0x100100));
+      const void* to = reinterpret_cast<const void*>(
+         static_cast<uintptr_t>(0x100000));
+      JmpCode jmpCode(from, to);
+
+      ASSERT_EQ(sizeof(uint32_t), jmpCode.getCodeSize());
+
+      const unsigned char* branch = static_cast<const unsigned char*>(
+         jmpCode.getCodeData());
+      ASSERT_EQ(static_cast<unsigned char>(0xC0), branch[0]);
+      ASSERT_EQ(static_cast<unsigned char>(0xFF), branch[1]);
+      ASSERT_EQ(static_cast<unsigned char>(0xFF), branch[2]);
+      ASSERT_EQ(static_cast<unsigned char>(0x17), branch[3]);
+   }
+
+   TEST(handles the direct branch range boundaries)
+   {
+      const void* from = reinterpret_cast<const void*>(
+         static_cast<uintptr_t>(0x10000000));
+      const void* highest = reinterpret_cast<const void*>(
+         static_cast<uintptr_t>(0x17FFFFFC));
+      const void* lowest = reinterpret_cast<const void*>(
+         static_cast<uintptr_t>(0x08000000));
+      const void* tooHigh = reinterpret_cast<const void*>(
+         static_cast<uintptr_t>(0x18000000));
+
+      JmpCode highestBranch(from, highest);
+      JmpCode lowestBranch(from, lowest);
+      JmpCode absoluteBranch(from, tooHigh);
+
+      ASSERT_EQ(sizeof(uint32_t), highestBranch.getCodeSize());
+      ASSERT_EQ(sizeof(uint32_t), lowestBranch.getCodeSize());
+      ASSERT_EQ(static_cast<size_t>(16), absoluteBranch.getCodeSize());
+   }
+
+   TEST(uses the absolute sequence when the target is unaligned)
+   {
+      const void* from = reinterpret_cast<const void*>(
+         static_cast<uintptr_t>(0x100000));
+      const void* unaligned = reinterpret_cast<const void*>(
+         static_cast<uintptr_t>(0x100002));
+      JmpCode jmpCode(from, unaligned);
+
+      ASSERT_EQ(static_cast<size_t>(16), jmpCode.getCodeSize());
+   }
+};
+
+#endif

--- a/tests/ut/TestFormatter.h
+++ b/tests/ut/TestFormatter.h
@@ -18,6 +18,7 @@
 
 #include <testcpp/testcpp.hpp>
 #include <mockcpp/Formatter.h>
+#include <limits.h>
 #include <stdio.h>
 
 USING_MOCKCPP_NS
@@ -304,7 +305,11 @@ public:
    void testShouldBeAbleToStringnizeNegativeChar()
    {
       char c = -1;
+#if CHAR_MIN < 0
       std::string expected("(char)0xff/-1");
+#else
+      std::string expected("(char)0xff/255");
+#endif
       TS_ASSERT_EQUALS(expected, toTypeAndValueString(c));
    }
 
@@ -412,4 +417,3 @@ public:
 #endif
    }
 };
-

--- a/tests/ut/TestMethodInfoReader.h
+++ b/tests/ut/TestMethodInfoReader.h
@@ -121,10 +121,25 @@ public:
       TS_ASSERT(getDeltaOfMethod(&Interface::base10) == getDeltaOfMethod(&Interface::base11));
    }
 
-	void testShouldNotBeEqualIf2MethodsDefinedInDifferentBaseInterface()
+   void testShouldNotBeEqualIf2MethodsDefinedInDifferentBaseInterface()
    {
       TS_ASSERT(getDeltaOfMethod(&Interface::base00) != getDeltaOfMethod(&Interface::base10));
    }
+
+#if defined(__aarch64__) || defined(__arm__)
+   void testShouldDecodeArmMemberFunctionPointersExactly()
+   {
+      TS_ASSERT_EQUALS(0, getIndexOfMethod(&Interface::base00));
+      TS_ASSERT_EQUALS(1, getIndexOfMethod(&Interface::base01));
+      TS_ASSERT_EQUALS(0, getIndexOfMethod(&Interface::base10));
+      TS_ASSERT_EQUALS(1, getIndexOfMethod(&Interface::base11));
+
+      TS_ASSERT_EQUALS(0, getDeltaOfMethod(&Interface::base00));
+      TS_ASSERT_EQUALS(0, getDeltaOfMethod(&Interface::base01));
+      TS_ASSERT_EQUALS(1, getDeltaOfMethod(&Interface::base10));
+      TS_ASSERT_EQUALS(1, getDeltaOfMethod(&Interface::base11));
+   }
+#endif
 
    void testShouldThrowAnExceptionIfTryToGetVtblIndexOfANonVirtualMethod()
    {
@@ -141,4 +156,3 @@ public:
       TS_ASSERT_THROWS(MOCKCPP_NS::getAddrOfMethod(&Interface::base00), MOCKCPP_NS::Exception);
    }
 };
-

--- a/tests/ut/cross_so/CMakeLists.txt
+++ b/tests/ut/cross_so/CMakeLists.txt
@@ -1,17 +1,28 @@
 ENABLE_LANGUAGE(ASM)
+FIND_PACKAGE(Threads REQUIRED)
 
 ADD_LIBRARY(mockcpp-aarch64-cross-so-target SHARED
   CrossSoTarget.cpp
   CrossSoArchitectureTargets.S)
+TARGET_LINK_LIBRARIES(mockcpp-aarch64-cross-so-target Threads::Threads)
 SET_TARGET_PROPERTIES(mockcpp-aarch64-cross-so-target PROPERTIES
-  COMPILE_FLAGS "-O0 -fno-lto"
+  COMPILE_FLAGS "-O0 -fplt -fno-lto"
   LINK_FLAGS "-Wl,-Bsymbolic-functions")
 
-FUNCTION(ADD_AARCH64_CROSS_SO_REGRESSION target binding_flag)
-  ADD_EXECUTABLE(${target} CrossSoRegression.cpp)
-  TARGET_LINK_LIBRARIES(${target}
-    mockcpp
-    mockcpp-aarch64-cross-so-target
+ADD_LIBRARY(mockcpp-aarch64-cross-so-target-now SHARED
+  CrossSoTarget.cpp
+  CrossSoArchitectureTargets.S)
+TARGET_LINK_LIBRARIES(mockcpp-aarch64-cross-so-target-now Threads::Threads)
+SET_TARGET_PROPERTIES(mockcpp-aarch64-cross-so-target-now PROPERTIES
+  COMPILE_FLAGS "-O0 -fplt -fno-lto"
+  LINK_FLAGS "-Wl,-Bsymbolic-functions,-z,now")
+
+FUNCTION(ADD_AARCH64_CROSS_SO_REGRESSION target binding_flag helper_target)
+   ADD_EXECUTABLE(${target} CrossSoRegression.cpp)
+   TARGET_LINK_LIBRARIES(${target}
+     mockcpp
+     ${helper_target}
+    Threads::Threads
     ${CMAKE_DL_LIBS})
   SET_TARGET_PROPERTIES(${target} PROPERTIES
     COMPILE_FLAGS "-O0 -fno-pic -fno-pie -fplt -fno-lto"
@@ -20,6 +31,10 @@ FUNCTION(ADD_AARCH64_CROSS_SO_REGRESSION target binding_flag)
 ENDFUNCTION()
 
 ADD_AARCH64_CROSS_SO_REGRESSION(
-  mockcpp-aarch64-cross-so-lazy "-z,lazy")
+  mockcpp-aarch64-cross-so-lazy
+  "-z,lazy"
+  mockcpp-aarch64-cross-so-target)
 ADD_AARCH64_CROSS_SO_REGRESSION(
-  mockcpp-aarch64-cross-so-now "-z,now")
+  mockcpp-aarch64-cross-so-now
+  "-z,now"
+  mockcpp-aarch64-cross-so-target-now)

--- a/tests/ut/cross_so/CMakeLists.txt
+++ b/tests/ut/cross_so/CMakeLists.txt
@@ -1,0 +1,25 @@
+ENABLE_LANGUAGE(ASM)
+
+ADD_LIBRARY(mockcpp-aarch64-cross-so-target SHARED
+  CrossSoTarget.cpp
+  CrossSoArchitectureTargets.S)
+SET_TARGET_PROPERTIES(mockcpp-aarch64-cross-so-target PROPERTIES
+  COMPILE_FLAGS "-O0 -fno-lto"
+  LINK_FLAGS "-Wl,-Bsymbolic-functions")
+
+FUNCTION(ADD_AARCH64_CROSS_SO_REGRESSION target binding_flag)
+  ADD_EXECUTABLE(${target} CrossSoRegression.cpp)
+  TARGET_LINK_LIBRARIES(${target}
+    mockcpp
+    mockcpp-aarch64-cross-so-target
+    ${CMAKE_DL_LIBS})
+  SET_TARGET_PROPERTIES(${target} PROPERTIES
+    COMPILE_FLAGS "-O0 -fno-pic -fno-pie -fplt -fno-lto"
+    LINK_FLAGS "-no-pie -Wl,${binding_flag}"
+    BUILD_RPATH "$ORIGIN")
+ENDFUNCTION()
+
+ADD_AARCH64_CROSS_SO_REGRESSION(
+  mockcpp-aarch64-cross-so-lazy "-z,lazy")
+ADD_AARCH64_CROSS_SO_REGRESSION(
+  mockcpp-aarch64-cross-so-now "-z,now")

--- a/tests/ut/cross_so/CrossSoArchitectureTargets.S
+++ b/tests/ut/cross_so/CrossSoArchitectureTargets.S
@@ -1,0 +1,50 @@
+   .text
+
+   .p2align 2
+   .global mockcpp_cross_so_short_target
+   .type mockcpp_cross_so_short_target, %function
+mockcpp_cross_so_short_target:
+   add w0, w0, #1
+   ret
+   .size mockcpp_cross_so_short_target, .-mockcpp_cross_so_short_target
+
+   // Keep this function immediately after the 8-byte target.  An unsafe
+   // 16-byte replacement of the target would overwrite it completely.
+   .global mockcpp_cross_so_short_neighbor
+   .type mockcpp_cross_so_short_neighbor, %function
+mockcpp_cross_so_short_neighbor:
+   mov w0, #123
+   ret
+   .size mockcpp_cross_so_short_neighbor, .-mockcpp_cross_so_short_neighbor
+
+   .p2align 2
+   .global mockcpp_cross_so_bti_target
+   .type mockcpp_cross_so_bti_target, %function
+mockcpp_cross_so_bti_target:
+   .inst 0xd503245f // bti c
+   nop
+   nop
+   nop
+   nop
+   add w0, w0, #1
+   ret
+   .size mockcpp_cross_so_bti_target, .-mockcpp_cross_so_bti_target
+
+   .p2align 2
+   .global mockcpp_cross_so_pac_target
+   .type mockcpp_cross_so_pac_target, %function
+mockcpp_cross_so_pac_target:
+   .inst 0xd503233f // paciasp
+   add w0, w0, #1
+   .inst 0xd50323bf // autiasp
+   ret
+   .size mockcpp_cross_so_pac_target, .-mockcpp_cross_so_pac_target
+
+   .global mockcpp_cross_so_pac_neighbor
+   .type mockcpp_cross_so_pac_neighbor, %function
+mockcpp_cross_so_pac_neighbor:
+   mov w0, #124
+   ret
+   .size mockcpp_cross_so_pac_neighbor, .-mockcpp_cross_so_pac_neighbor
+
+   .section .note.GNU-stack,"",%progbits

--- a/tests/ut/cross_so/CrossSoRegression.cpp
+++ b/tests/ut/cross_so/CrossSoRegression.cpp
@@ -1,6 +1,10 @@
 #include <mockcpp/GlobalMockObject.h>
 #include <mockcpp/mokc.h>
 
+#include <pthread.h>
+#include <sys/socket.h>
+#include <dlfcn.h>
+
 #include "CrossSoTarget.h"
 
 USING_MOCKCPP_NS
@@ -20,10 +24,33 @@ bool hasInstruction(const void* address,
           instruction[2] == 0x03U && instruction[3] == 0xd5U;
 }
 
+bool belongsToMainExecutable(const void* address, const void* mainAddress)
+{
+   Dl_info symbolInfo;
+   Dl_info mainInfo;
+   return ::dladdr(address, &symbolInfo) != 0 &&
+          ::dladdr(mainAddress, &mainInfo) != 0 &&
+          symbolInfo.dli_fbase == mainInfo.dli_fbase;
+}
+
 }
 
 int main()
 {
+   if(!belongsToMainExecutable(reinterpret_cast<const void*>(&socket),
+                               reinterpret_cast<const void*>(&main)) ||
+      !belongsToMainExecutable(reinterpret_cast<const void*>(&listen),
+                               reinterpret_cast<const void*>(&main)) ||
+      !belongsToMainExecutable(
+         reinterpret_cast<const void*>(&pthread_rwlock_rdlock),
+         reinterpret_cast<const void*>(&main)) ||
+      !belongsToMainExecutable(
+         reinterpret_cast<const void*>(&pthread_rwlock_destroy),
+         reinterpret_cast<const void*>(&main)))
+   {
+      return 9;
+   }
+
    const void* executableAddress =
       reinterpret_cast<const void*>(&mockcpp_cross_so_target);
    const bool executablePltHasBti =
@@ -81,11 +108,9 @@ int main()
       .stubs()
       .will(returnValue(78));
 
-   // A short target may be hooked with a 4-byte direct branch when the stub
-   // happens to be nearby, or safely left local when a 16-byte jump would
-   // overwrite the following function.  It must never corrupt its neighbor.
-   const int shortResult = mockcpp_cross_so_short_caller(5);
-   if((shortResult != 6 && shortResult != 78) ||
+   // A far-away short target uses a 4-byte branch to a nearby trampoline.  It
+   // must be hooked without overwriting the following function.
+   if(mockcpp_cross_so_short_caller(5) != 78 ||
       shortExecutableFunction(5) != 78 ||
       mockcpp_cross_so_short_neighbor() != 123 ||
       (shortPltHasBti &&
@@ -172,6 +197,73 @@ int main()
    }
 
    GlobalMockObject::reset();
-   return mockcpp_cross_so_pac_caller(5) == 6 &&
-          mockcpp_cross_so_pac_neighbor() == 124 ? 0 : 42;
+   if(mockcpp_cross_so_pac_caller(5) != 6 ||
+      mockcpp_cross_so_pac_neighbor() != 124)
+   {
+      return 42;
+   }
+
+   if(mockcpp_cross_so_socket_caller() != -1)
+   {
+      return 49;
+   }
+
+   MOCKER(socket).stubs().will(returnValue(501));
+   if(mockcpp_cross_so_socket_caller() != 501)
+   {
+      GlobalMockObject::reset();
+      return 50;
+   }
+   GlobalMockObject::reset();
+   if(mockcpp_cross_so_socket_caller() != -1)
+   {
+      return 53;
+   }
+
+   if(mockcpp_cross_so_listen_caller() != -1)
+   {
+      return 54;
+   }
+   MOCKER(listen).stubs().will(returnValue(502));
+   if(mockcpp_cross_so_listen_caller() != 502)
+   {
+      GlobalMockObject::reset();
+      return 51;
+   }
+   GlobalMockObject::reset();
+   if(mockcpp_cross_so_listen_caller() != -1)
+   {
+      return 55;
+   }
+
+   if(mockcpp_cross_so_rwlock_caller() != 0)
+   {
+      return 56;
+   }
+   MOCKER(pthread_rwlock_rdlock).stubs().will(returnValue(503));
+   if(mockcpp_cross_so_rwlock_caller() != 503)
+   {
+      GlobalMockObject::reset();
+      return 52;
+   }
+
+   GlobalMockObject::reset();
+   if(mockcpp_cross_so_rwlock_caller() != 0)
+   {
+      return 57;
+   }
+
+   if(mockcpp_cross_so_rwlock_destroy_caller() != 0)
+   {
+      return 58;
+   }
+   MOCKER(pthread_rwlock_destroy).stubs().will(returnValue(504));
+   if(mockcpp_cross_so_rwlock_destroy_caller() != 504)
+   {
+      GlobalMockObject::reset();
+      return 59;
+   }
+
+   GlobalMockObject::reset();
+   return mockcpp_cross_so_rwlock_destroy_caller() == 0 ? 0 : 60;
 }

--- a/tests/ut/cross_so/CrossSoRegression.cpp
+++ b/tests/ut/cross_so/CrossSoRegression.cpp
@@ -1,0 +1,177 @@
+#include <mockcpp/GlobalMockObject.h>
+#include <mockcpp/mokc.h>
+
+#include "CrossSoTarget.h"
+
+USING_MOCKCPP_NS
+
+namespace
+{
+
+typedef int (*CrossSoFunction)(int);
+
+bool hasInstruction(const void* address,
+                    unsigned char byte0,
+                    unsigned char byte1)
+{
+   const unsigned char* instruction =
+      static_cast<const unsigned char*>(address);
+   return instruction[0] == byte0 && instruction[1] == byte1 &&
+          instruction[2] == 0x03U && instruction[3] == 0xd5U;
+}
+
+}
+
+int main()
+{
+   const void* executableAddress =
+      reinterpret_cast<const void*>(&mockcpp_cross_so_target);
+   const bool executablePltHasBti =
+      hasInstruction(executableAddress, 0x5fU, 0x24U);
+   CrossSoFunction executableFunction =
+      reinterpret_cast<CrossSoFunction>(
+         const_cast<void*>(executableAddress));
+
+   // The regression is only meaningful when the executable exposes the
+   // imported function through its canonical PLT while the shared object
+   // uses the real local definition.
+   if(executableAddress == mockcpp_cross_so_target_address())
+   {
+      return 10;
+   }
+
+   if(mockcpp_cross_so_caller(5) != 6)
+   {
+      return 11;
+   }
+
+   MOCKER(mockcpp_cross_so_target)
+      .stubs()
+      .will(returnValue(77));
+
+   if(mockcpp_cross_so_caller(5) != 77 || executableFunction(5) != 77 ||
+      (executablePltHasBti &&
+       !hasInstruction(executableAddress, 0x5fU, 0x24U)))
+   {
+      GlobalMockObject::reset();
+      return 12;
+   }
+
+   GlobalMockObject::reset();
+   if(mockcpp_cross_so_caller(5) != 6)
+   {
+      return 13;
+   }
+
+   const void* shortExecutableAddress =
+      reinterpret_cast<const void*>(&mockcpp_cross_so_short_target);
+   const bool shortPltHasBti =
+      hasInstruction(shortExecutableAddress, 0x5fU, 0x24U);
+   CrossSoFunction shortExecutableFunction =
+      reinterpret_cast<CrossSoFunction>(
+         const_cast<void*>(shortExecutableAddress));
+   if(shortExecutableAddress == mockcpp_cross_so_short_target_address() ||
+      mockcpp_cross_so_short_caller(5) != 6 ||
+      mockcpp_cross_so_short_neighbor() != 123)
+   {
+      return 20;
+   }
+
+   MOCKER(mockcpp_cross_so_short_target)
+      .stubs()
+      .will(returnValue(78));
+
+   // A short target may be hooked with a 4-byte direct branch when the stub
+   // happens to be nearby, or safely left local when a 16-byte jump would
+   // overwrite the following function.  It must never corrupt its neighbor.
+   const int shortResult = mockcpp_cross_so_short_caller(5);
+   if((shortResult != 6 && shortResult != 78) ||
+      shortExecutableFunction(5) != 78 ||
+      mockcpp_cross_so_short_neighbor() != 123 ||
+      (shortPltHasBti &&
+       !hasInstruction(shortExecutableAddress, 0x5fU, 0x24U)))
+   {
+      GlobalMockObject::reset();
+      return 21;
+   }
+
+   GlobalMockObject::reset();
+   if(mockcpp_cross_so_short_caller(5) != 6 ||
+      mockcpp_cross_so_short_neighbor() != 123)
+   {
+      return 22;
+   }
+
+   const void* btiExecutableAddress =
+      reinterpret_cast<const void*>(&mockcpp_cross_so_bti_target);
+   const bool btiPltHasBti =
+      hasInstruction(btiExecutableAddress, 0x5fU, 0x24U);
+   CrossSoFunction btiExecutableFunction =
+      reinterpret_cast<CrossSoFunction>(
+         const_cast<void*>(btiExecutableAddress));
+   const void* btiRealAddress = mockcpp_cross_so_bti_target_address();
+   if(btiExecutableAddress == mockcpp_cross_so_bti_target_address() ||
+      mockcpp_cross_so_bti_caller(5) != 6 ||
+      !hasInstruction(btiRealAddress, 0x5fU, 0x24U))
+   {
+      return 30;
+   }
+
+   MOCKER(mockcpp_cross_so_bti_target)
+      .stubs()
+      .will(returnValue(79));
+
+   if(mockcpp_cross_so_bti_caller(5) != 79 ||
+      btiExecutableFunction(5) != 79 ||
+      !hasInstruction(btiRealAddress, 0x5fU, 0x24U) ||
+      (btiPltHasBti &&
+       !hasInstruction(btiExecutableAddress, 0x5fU, 0x24U)))
+   {
+      GlobalMockObject::reset();
+      return 31;
+   }
+
+   GlobalMockObject::reset();
+   if(mockcpp_cross_so_bti_caller(5) != 6)
+   {
+      return 32;
+   }
+
+   const void* pacExecutableAddress =
+      reinterpret_cast<const void*>(&mockcpp_cross_so_pac_target);
+   const bool pacPltHasBti =
+      hasInstruction(pacExecutableAddress, 0x5fU, 0x24U);
+   CrossSoFunction pacExecutableFunction =
+      reinterpret_cast<CrossSoFunction>(
+         const_cast<void*>(pacExecutableAddress));
+   const void* pacRealAddress = mockcpp_cross_so_pac_target_address();
+   if(pacExecutableAddress == mockcpp_cross_so_pac_target_address() ||
+      mockcpp_cross_so_pac_caller(5) != 6 ||
+      mockcpp_cross_so_pac_neighbor() != 124 ||
+      !hasInstruction(pacRealAddress, 0x3fU, 0x23U))
+   {
+      return 40;
+   }
+
+   MOCKER(mockcpp_cross_so_pac_target)
+      .stubs()
+      .will(returnValue(80));
+
+   // PACIASP/PACIBSP cannot be retained before a normal mock stub and cannot
+   // be replaced on a BTI-guarded page.  The safe behavior is to leave the
+   // shared-object-local entry untouched.
+   if(mockcpp_cross_so_pac_caller(5) != 6 ||
+      pacExecutableFunction(5) != 80 ||
+      mockcpp_cross_so_pac_neighbor() != 124 ||
+      !hasInstruction(pacRealAddress, 0x3fU, 0x23U) ||
+      (pacPltHasBti &&
+       !hasInstruction(pacExecutableAddress, 0x5fU, 0x24U)))
+   {
+      GlobalMockObject::reset();
+      return 41;
+   }
+
+   GlobalMockObject::reset();
+   return mockcpp_cross_so_pac_caller(5) == 6 &&
+          mockcpp_cross_so_pac_neighbor() == 124 ? 0 : 42;
+}

--- a/tests/ut/cross_so/CrossSoTarget.cpp
+++ b/tests/ut/cross_so/CrossSoTarget.cpp
@@ -1,5 +1,8 @@
 #include "CrossSoTarget.h"
 
+#include <pthread.h>
+#include <sys/socket.h>
+
 extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
 int mockcpp_cross_so_target(int value)
 {
@@ -56,4 +59,36 @@ extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
 const void* mockcpp_cross_so_pac_target_address()
 {
    return reinterpret_cast<const void*>(&mockcpp_cross_so_pac_target);
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_socket_caller()
+{
+   return ::socket(-1, -1, -1);
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_listen_caller()
+{
+   return ::listen(-1, -1);
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_rwlock_caller()
+{
+   pthread_rwlock_t lock = PTHREAD_RWLOCK_INITIALIZER;
+   const int lockResult = ::pthread_rwlock_rdlock(&lock);
+   if(lockResult == 0)
+   {
+      ::pthread_rwlock_unlock(&lock);
+   }
+   ::pthread_rwlock_destroy(&lock);
+   return lockResult;
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_rwlock_destroy_caller()
+{
+   pthread_rwlock_t lock = PTHREAD_RWLOCK_INITIALIZER;
+   return ::pthread_rwlock_destroy(&lock);
 }

--- a/tests/ut/cross_so/CrossSoTarget.cpp
+++ b/tests/ut/cross_so/CrossSoTarget.cpp
@@ -1,0 +1,59 @@
+#include "CrossSoTarget.h"
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_target(int value)
+{
+#if defined(__aarch64__)
+   // Keep enough replaceable instructions for mockcpp's far-jump sequence.
+   __asm__ __volatile__("nop\n\tnop\n\tnop\n\tnop");
+#endif
+   return value + 1;
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_caller(int value)
+{
+   return mockcpp_cross_so_target(value);
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+const void* mockcpp_cross_so_target_address()
+{
+   return reinterpret_cast<const void*>(&mockcpp_cross_so_target);
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_short_caller(int value)
+{
+   return mockcpp_cross_so_short_target(value);
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+const void* mockcpp_cross_so_short_target_address()
+{
+   return reinterpret_cast<const void*>(&mockcpp_cross_so_short_target);
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_bti_caller(int value)
+{
+   return mockcpp_cross_so_bti_target(value);
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+const void* mockcpp_cross_so_bti_target_address()
+{
+   return reinterpret_cast<const void*>(&mockcpp_cross_so_bti_target);
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_pac_caller(int value)
+{
+   return mockcpp_cross_so_pac_target(value);
+}
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+const void* mockcpp_cross_so_pac_target_address()
+{
+   return reinterpret_cast<const void*>(&mockcpp_cross_so_pac_target);
+}

--- a/tests/ut/cross_so/CrossSoTarget.h
+++ b/tests/ut/cross_so/CrossSoTarget.h
@@ -51,4 +51,16 @@ int mockcpp_cross_so_pac_neighbor();
 extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
 const void* mockcpp_cross_so_pac_target_address();
 
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_socket_caller();
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_listen_caller();
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_rwlock_caller();
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_rwlock_destroy_caller();
+
 #endif

--- a/tests/ut/cross_so/CrossSoTarget.h
+++ b/tests/ut/cross_so/CrossSoTarget.h
@@ -1,0 +1,54 @@
+#ifndef __MOCKCPP_CROSS_SO_TARGET_H__
+#define __MOCKCPP_CROSS_SO_TARGET_H__
+
+#if defined(__GNUC__)
+#  define MOCKCPP_CROSS_SO_API __attribute__((visibility("default")))
+#  define MOCKCPP_CROSS_SO_NOINLINE __attribute__((noinline))
+#else
+#  define MOCKCPP_CROSS_SO_API
+#  define MOCKCPP_CROSS_SO_NOINLINE
+#endif
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_target(int value);
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_caller(int value);
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+const void* mockcpp_cross_so_target_address();
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_short_target(int value);
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_short_caller(int value);
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_short_neighbor();
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+const void* mockcpp_cross_so_short_target_address();
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_bti_target(int value);
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_bti_caller(int value);
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+const void* mockcpp_cross_so_bti_target_address();
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_pac_target(int value);
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_pac_caller(int value);
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+int mockcpp_cross_so_pac_neighbor();
+
+extern "C" MOCKCPP_CROSS_SO_API MOCKCPP_CROSS_SO_NOINLINE
+const void* mockcpp_cross_so_pac_target_address();
+
+#endif


### PR DESCRIPTION
- select jump code by CPU ISA instead of pointer width
- add absolute jump trampolines for AArch64 and ARM32
- support A32 and aligned/halfword-aligned Thumb-2 entries
- normalize Thumb function addresses before patching
- flush instruction cache after installing and restoring hooks
- avoid unaligned address writes in x86 jump generation
- add regression coverage for restoring C functions after reset

Verified on x86_64, AArch64, ARM32 A32, and ARM32 Thumb-2. All 275 native unit tests pass.